### PR TITLE
Show vispy.app.run() command

### DIFF
--- a/plato/draw/vispy/__init__.py
+++ b/plato/draw/vispy/__init__.py
@@ -10,6 +10,7 @@ Select the backend to use with the standard vispy mechanism::
   vispy.app.use_app('ipynb_webgl')
   # use pyside2
   vispy.app.use_app('pyside2')
+  vispy.app.run()
 
 """
 

--- a/plato/draw/vispy/__init__.py
+++ b/plato/draw/vispy/__init__.py
@@ -10,6 +10,8 @@ Select the backend to use with the standard vispy mechanism::
   vispy.app.use_app('ipynb_webgl')
   # use pyside2
   vispy.app.use_app('pyside2')
+  scene = plato.draw.vispy.Scene(...)
+  scene.show()
   vispy.app.run()
 
 """


### PR DESCRIPTION
The `vispy.app.run()` command is needed to launch a window for the vispy application. I'm not 100% sure if this should go here or someplace else.