### PR TITLE
Added default lights to the pythreejs backend.

### DIFF
--- a/plato/draw/pythreejs/Scene.py
+++ b/plato/draw/pythreejs/Scene.py
@@ -162,7 +162,8 @@ class Scene(draw.Scene):
             self._remove_lights()
             # Create new lights
             dz = np.linalg.norm(self.size) * self._clip_scale
-            for light_vector in np.atleast_2d(np.asarray(self.get_feature_config(name)['value'])):
+            for light_vector in np.atleast_2d(
+                    self.get_feature_config(name).get('value', DEFAULT_DIRECTIONAL_LIGHTS)):
                 position = (-light_vector * dz).tolist()
                 light = pythreejs.DirectionalLight(
                     color='#ffffff', position=position, intensity=np.linalg.norm(light_vector))


### PR DESCRIPTION
This PR resolves #12 by enabling the `DEFAULT_DIRECTIONAL_LIGHTS` automatically.

Any values provided subsequently, such as `scene.enable('directional_light', value=[[1, 0, 0]])` will disable the automatic lighting and replace it with the user-specified lights.

## Minimal example:
```python
import numpy as np
import plato.draw.pythreejs as draw
start_points = np.array([[0, 0, 0], [1, 0.2, 0.2]])
end_points = start_points + np.array([[0, 1, 0]])
widths = np.array([0.1, 0.1])
colors = np.array([[1, 0, 0, 1], [0, 0, 1, 1]])
lines = draw.Lines(start_points=start_points, end_points=end_points, colors=colors)
spheres = draw.Spheres(positions=[[-1, 0, 0.5]], colors=[[1, 1, 0, 1]], radii=[0.2])
scene = draw.Scene([lines, spheres], zoom=10)
#scene.enable('directional_light', value=[[1, 0, 0]])
scene.show()
```

## With default lights (second to last line commented)
![image](https://user-images.githubusercontent.com/3943761/52984780-dca34080-33be-11e9-8f16-c38e34785eea.png)


## With custom lights (second to last line uncommented)
![image](https://user-images.githubusercontent.com/3943761/52984783-e462e500-33be-11e9-9152-4e7fe30261d8.png)
