### PR TITLE
Material transparency in pythreejs

### DIFF
--- a/plato/draw/pythreejs/__init__.py
+++ b/plato/draw/pythreejs/__init__.py
@@ -1,3 +1,15 @@
+"""
+The `pythreejs <https://github.com/jupyter-widgets/pythreejs>`_
+backend renders scenes using `three.js <https://threejs.org/>`_
+and is compatible with Jupyter notebooks.
+
+.. note::
+
+    To enable translucency in the pythreejs backend, a primitive must have the
+    same value of alpha (less than 1) for all colors.
+
+"""
+
 from .ConvexPolyhedra import ConvexPolyhedra
 from .ConvexSpheropolyhedra import ConvexSpheropolyhedra
 from .Lines import Lines

--- a/plato/draw/pythreejs/internal.py
+++ b/plato/draw/pythreejs/internal.py
@@ -38,8 +38,16 @@ class ThreeJSPrimitive:
         indices = indices.reshape((-1,)).astype(np.uint32)
 
         prim = self.threejs_primitive
+
+        colors = colors.astype(np.float32).reshape((-1, 4))
+        if colors[0, 3] < 1 and np.allclose(colors[:, 3], colors[0, 3]):
+            # All colors have the same alpha
+            prim.material.transparent = True
+            prim.material.depthWrite = False
+            prim.material.opacity = colors[0, 3]
+
         attribs = dict(position=pythreejs.BufferAttribute(images.astype(np.float32).reshape((-1, 3))),
-                       color=pythreejs.BufferAttribute(colors.astype(np.float32).reshape((-1, 4))),
+                       color=pythreejs.BufferAttribute(colors),
                        index=pythreejs.BufferAttribute(indices))
         if normals is not None:
             attribs['normal'] = pythreejs.BufferAttribute(normals.astype(np.float32).reshape((-1, 3)))

--- a/plato/draw/pythreejs/internal.py
+++ b/plato/draw/pythreejs/internal.py
@@ -41,7 +41,7 @@ class ThreeJSPrimitive:
 
         colors = colors.astype(np.float32).reshape((-1, 4))
         if colors[0, 3] < 1 and np.allclose(colors[:, 3], colors[0, 3]):
-            # All colors have the same alpha
+            # If all colors have the same alpha, enable material transparency
             prim.material.transparent = True
             prim.material.depthWrite = False
             prim.material.opacity = colors[0, 3]

--- a/test/test_scenes.py
+++ b/test/test_scenes.py
@@ -180,6 +180,7 @@ def convex_polyhedra(seed=16, num_particles=3):
     np.random.seed(seed)
     positions = np.random.uniform(0, 9, (num_particles, 3))
     colors = np.random.uniform(.75, .9, (num_particles, 4))**1.5
+    colors[:, 3] = 0.7
     orientations = np.random.rand(num_particles, 4)
     orientations /= np.linalg.norm(orientations, axis=-1, keepdims=True)
 


### PR DESCRIPTION
This PR resolves #14 by adding material transparency to the pythreejs backend.

This only works when all colors in the primitive have the same alpha value, and it doesn't trigger material transparency unless those colors have alpha < 1.

Three.js doesn't support RGBA values for each vertex, which may be necessary to make this work for individual shapes in a primitive (https://github.com/mrdoob/three.js/issues/2118). It might be possible to enhance this feature by using custom shaders, but that's currently out of scope for me.

To show this transparency more clearly, I modified the ConvexPolyhedra test to make those shapes slightly more transparent.

## Example (rotated from default view for the test scene)
![image](https://user-images.githubusercontent.com/3943761/52990303-9ad1c480-33d5-11e9-86d4-d2c9b5bc7bb6.png)
