### PR TITLE
Updated fresnel backend to support new features of fresnel v0.8.0. 

### DIFF
--- a/plato/draw/fresnel/Spheropolygons.py
+++ b/plato/draw/fresnel/Spheropolygons.py
@@ -4,8 +4,8 @@ from ... import draw
 from .FresnelPrimitive import FresnelPrimitive
 import rowan
 
-class Polygons(draw.Polygons, FresnelPrimitive):
-    __doc__ = draw.Polygons.__doc__
+class Spheropolygons(draw.Spheropolygons, FresnelPrimitive):
+    __doc__ = draw.Spheropolygons.__doc__
 
     def __init__(self, *args, material=None, **kwargs):
         FresnelPrimitive.__init__(self, *args, material, **kwargs)
@@ -20,6 +20,7 @@ class Polygons(draw.Polygons, FresnelPrimitive):
             position=self.positions,
             angle=rowan.geometry.angle(rowan.normalize(self.orientations)),
             color=fresnel.color.linear(self.colors),
+            rounding_radius=self.radius,
             material=self._material,
             outline_width=self.outline)
         return geometry

--- a/plato/draw/fresnel/__init__.py
+++ b/plato/draw/fresnel/__init__.py
@@ -13,9 +13,10 @@ All fresnel primitives accept an argument ``material`` of type :py:class:`fresne
 
 from .Scene import Scene
 
-#from .Arrows2D import Arrows2D  # not working yet
+from .Arrows2D import Arrows2D
 from .Disks import Disks
 from .Polygons import Polygons
+from .Spheropolygons import Spheropolygons
 from .Lines import Lines
 from .Spheres import Spheres
 from .ConvexPolyhedra import ConvexPolyhedra


### PR DESCRIPTION
Updated for [fresnel v0.8.0](https://github.com/glotzerlab/fresnel/releases/tag/v0.8.0). Adds arrows and spheropolygons to supported fresnel shapes.

## Example
![fresnel_spheropolygons](https://user-images.githubusercontent.com/3943761/53823315-63f7c480-3f26-11e9-88c6-16bd2eaf43b5.png)
(Note that since fresnel uses angles instead of quaternions, the arrows do not scale down. Also the lack of translucency makes this scene look different than in other backends.)