### PR TITLE
Rename DiskUnion and SphereUnion to plural form

### DIFF
--- a/doc/source/fresnel.rst
+++ b/doc/source/fresnel.rst
@@ -24,7 +24,7 @@ Fresnel Backend
 .. autoclass:: Lines
    :members:
 
-.. autoclass:: SphereUnion
+.. autoclass:: SphereUnions
    :members:
 
 .. autoclass:: Spheres

--- a/doc/source/matplotlib.rst
+++ b/doc/source/matplotlib.rst
@@ -12,7 +12,7 @@ Matplotlib Backend
 .. autoclass:: Arrows2D
    :members:
 
-.. autoclass:: DiskUnion
+.. autoclass:: DiskUnions
    :members:
 
 .. autoclass:: Disks

--- a/doc/source/povray.rst
+++ b/doc/source/povray.rst
@@ -21,7 +21,7 @@ Povray Backend
 .. autoclass:: Mesh
    :members:
 
-.. autoclass:: SphereUnion
+.. autoclass:: SphereUnions
    :members:
 
 .. autoclass:: Spheres

--- a/doc/source/primitives.rst
+++ b/doc/source/primitives.rst
@@ -44,7 +44,7 @@ Base Drawing Module
 .. autoclass:: Arrows2D
    :members:
 
-.. autoclass:: DiskUnion
+.. autoclass:: DiskUnions
    :members:
 
 .. autoclass:: Disks
@@ -77,7 +77,7 @@ Base Drawing Module
 .. autoclass:: SpherePoints
    :members:
 
-.. autoclass:: SphereUnion
+.. autoclass:: SphereUnions
    :members:
 
 .. autoclass:: Spheres

--- a/doc/source/vispy.rst
+++ b/doc/source/vispy.rst
@@ -12,7 +12,7 @@ Vispy Backend
 .. autoclass:: Arrows2D
    :members:
 
-.. autoclass:: DiskUnion
+.. autoclass:: DiskUnions
    :members:
 
 .. autoclass:: Disks
@@ -45,7 +45,7 @@ Vispy Backend
 .. autoclass:: SpherePoints
    :members:
 
-.. autoclass:: SphereUnion
+.. autoclass:: SphereUnions
    :members:
 
 .. autoclass:: Spheres

--- a/plato/draw/DiskUnions.py
+++ b/plato/draw/DiskUnions.py
@@ -3,10 +3,10 @@ import numpy as np
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator
-class DiskUnion(Shape):
+class DiskUnions(Shape):
     """A collection of identical disk-union bodies in 2D.
 
-    A `DiskUnion` object consists of one or more disks, each with its
+    A `DiskUnions` object consists of one or more disks, each with its
     own radius and color. Each object has its own position and
     orientation that affect the final position of the constituent
     disks.

--- a/plato/draw/SphereUnions.py
+++ b/plato/draw/SphereUnions.py
@@ -3,11 +3,11 @@ import numpy as np
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator
-class SphereUnion(Shape):
+class SphereUnions(Shape):
     """A collection of identical sphere-union bodies in 3D.
 
-    A `SphereUnion` object is a union of spheres, each of which has
-    its own color, radius, and local position. The `SphereUnion`
+    A `SphereUnions` object is a union of spheres, each of which has
+    its own color, radius, and local position. The `SphereUnions`
     object can be rigidly rotated and translated via its position and
     orientation attributes.
     """

--- a/plato/draw/__init__.py
+++ b/plato/draw/__init__.py
@@ -2,14 +2,14 @@ from .Scene import Scene
 
 from .Arrows2D import Arrows2D
 from .Disks import Disks
-from .DiskUnion import DiskUnion
+from .DiskUnions import DiskUnions
 from .Polygons import Polygons
 from .Spheropolygons import Spheropolygons
 from .Voronoi import Voronoi
 from .Lines import Lines
 from .Spheres import Spheres
 from .SpherePoints import SpherePoints
-from .SphereUnion import SphereUnion
+from .SphereUnions import SphereUnions
 from .Mesh import Mesh
 from .ConvexPolyhedra import ConvexPolyhedra
 from .ConvexSpheropolyhedra import ConvexSpheropolyhedra

--- a/plato/draw/fresnel/SphereUnions.py
+++ b/plato/draw/fresnel/SphereUnions.py
@@ -4,12 +4,12 @@ from ... import math
 from .FresnelPrimitive import FresnelPrimitive
 import numpy as np
 
-class SphereUnion(draw.SphereUnion, FresnelPrimitive):
-    __doc__ = draw.SphereUnion.__doc__
+class SphereUnions(draw.SphereUnions, FresnelPrimitive):
+    __doc__ = draw.SphereUnions.__doc__
 
     def __init__(self, *args, material=None, **kwargs):
         FresnelPrimitive.__init__(self, *args, material, **kwargs)
-        draw.SphereUnion.__init__(self, *args, **kwargs)
+        draw.SphereUnions.__init__(self, *args, **kwargs)
 
     def render(self, scene):
 

--- a/plato/draw/fresnel/__init__.py
+++ b/plato/draw/fresnel/__init__.py
@@ -19,5 +19,5 @@ from .Polygons import Polygons
 from .Spheropolygons import Spheropolygons
 from .Lines import Lines
 from .Spheres import Spheres
-from .SphereUnion import SphereUnion
+from .SphereUnions import SphereUnions
 from .ConvexPolyhedra import ConvexPolyhedra

--- a/plato/draw/matplotlib/DiskUnions.py
+++ b/plato/draw/matplotlib/DiskUnions.py
@@ -4,8 +4,8 @@ from matplotlib.patches import Circle, Wedge, Polygon
 from matplotlib.collections import PatchCollection
 from matplotlib.transforms import Affine2D
 
-class DiskUnion(draw.DiskUnion):
-    __doc__ = draw.DiskUnion.__doc__
+class DiskUnions(draw.DiskUnions):
+    __doc__ = draw.DiskUnions.__doc__
 
     def render(self, axes, aa_pixel_size=0, **kwargs):
         collections = []

--- a/plato/draw/matplotlib/__init__.py
+++ b/plato/draw/matplotlib/__init__.py
@@ -8,7 +8,7 @@ shapes using this backend.
 from .Scene import Scene
 
 from .Disks import Disks
-from .DiskUnion import DiskUnion
+from .DiskUnions import DiskUnions
 from .Arrows2D import Arrows2D
 from .Polygons import Polygons
 from .Spheropolygons import Spheropolygons

--- a/plato/draw/povray/SphereUnions.py
+++ b/plato/draw/povray/SphereUnions.py
@@ -2,8 +2,8 @@ import numpy as np
 from ... import draw
 from ... import math
 
-class SphereUnion(draw.SphereUnion):
-    __doc__ = draw.SphereUnion.__doc__
+class SphereUnions(draw.SphereUnions):
+    __doc__ = draw.SphereUnions.__doc__
 
     def render(self, rotation=(1, 0, 0, 0), **kwargs):
         rotation = np.asarray(rotation)

--- a/plato/draw/povray/__init__.py
+++ b/plato/draw/povray/__init__.py
@@ -6,7 +6,7 @@ from .Scene import Scene
 
 from .Lines import Lines
 from .Spheres import Spheres
-from .SphereUnion import SphereUnion
+from .SphereUnions import SphereUnions
 from .Mesh import Mesh
 from .ConvexPolyhedra import ConvexPolyhedra
 from .ConvexSpheropolyhedra import ConvexSpheropolyhedra

--- a/plato/draw/vispy/DiskUnions.py
+++ b/plato/draw/vispy/DiskUnions.py
@@ -8,8 +8,8 @@ from ..internal import ShapeAttribute
 from vispy import gloo
 
 @GLShapeDecorator
-class DiskUnion(draw.DiskUnion, GLPrimitive):
-    __doc__ = draw.DiskUnion.__doc__
+class DiskUnions(draw.DiskUnions, GLPrimitive):
+    __doc__ = draw.DiskUnions.__doc__
 
     shaders = {}
 
@@ -130,7 +130,7 @@ class DiskUnion(draw.DiskUnion, GLPrimitive):
 
     def __init__(self, *args, **kwargs):
         GLPrimitive.__init__(self)
-        draw.DiskUnion.__init__(self, *args, **kwargs)
+        draw.DiskUnions.__init__(self, *args, **kwargs)
 
     def update_arrays(self):
 

--- a/plato/draw/vispy/SphereUnions.py
+++ b/plato/draw/vispy/SphereUnions.py
@@ -8,8 +8,8 @@ from ..internal import ShapeAttribute
 from vispy import gloo
 
 @GLShapeDecorator
-class SphereUnion(draw.SphereUnion, GLPrimitive):
-    __doc__ = draw.SphereUnion.__doc__
+class SphereUnions(draw.SphereUnions, GLPrimitive):
+    __doc__ = draw.SphereUnions.__doc__
 
     shaders = {}
 
@@ -197,7 +197,7 @@ class SphereUnion(draw.SphereUnion, GLPrimitive):
 
     def __init__(self, *args, **kwargs):
         GLPrimitive.__init__(self)
-        draw.SphereUnion.__init__(self, *args, **kwargs)
+        draw.SphereUnions.__init__(self, *args, **kwargs)
 
     def update_arrays(self):
 

--- a/plato/draw/vispy/__init__.py
+++ b/plato/draw/vispy/__init__.py
@@ -17,14 +17,14 @@ from .Scene import Scene
 
 from .Arrows2D import Arrows2D
 from .Disks import Disks
-from .DiskUnion import DiskUnion
+from .DiskUnions import DiskUnions
 from .Polygons import Polygons
 from .Spheropolygons import Spheropolygons
 from .Voronoi import Voronoi
 from .Lines import Lines
 from .Spheres import Spheres
 from .SpherePoints import SpherePoints
-from .SphereUnion import SphereUnion
+from .SphereUnions import SphereUnions
 from .Mesh import Mesh
 from .ConvexPolyhedra import ConvexPolyhedra
 from .ConvexSpheropolyhedra import ConvexSpheropolyhedra

--- a/test/test_scenes.py
+++ b/test/test_scenes.py
@@ -114,7 +114,7 @@ def disk_union(seed=15, num_unions=5):
     colors = np.random.rand(len(points), 4)
     radii = np.random.uniform(0.5, 1.0, (len(points), 1))
 
-    prim1 = draw.DiskUnion(positions=positions, angles=angles, colors=colors,
+    prim1 = draw.DiskUnions(positions=positions, angles=angles, colors=colors,
                            points=points, radii=radii, outline=.125)
 
     scene = draw.Scene([prim1], zoom=2, features=dict(pan=True))
@@ -131,7 +131,7 @@ def sphere_union(seed=15, num_unions=5):
     colors = np.random.rand(len(points), 4)
     radii = np.random.uniform(0.5, 1.0, (len(points), 1))
 
-    prim1 = draw.SphereUnion(positions=positions, orientations=orientations,colors=colors,
+    prim1 = draw.SphereUnions(positions=positions, orientations=orientations,colors=colors,
                            points=points, radii=radii, outline=.10)
     features = dict(ambient_light=.25)
     features['directional_light'] = .5*np.array([(.5, .25, -.5), (0, -.25, -.25)])


### PR DESCRIPTION
This makes the naming scheme more consistent: all primitives that draw collections of objects have plural names.