### PR TITLE
Enable directional_light by default in all scenes

### DIFF
--- a/plato/draw/Scene.py
+++ b/plato/draw/Scene.py
@@ -2,6 +2,12 @@ import logging
 import numpy as np
 from .internal import Shape
 
+DEFAULT_DIRECTIONAL_LIGHTS = (
+    [ 0.4,  -0.4,    -0.4 ],
+    [-0.25, -0.0625, -0.25 ],
+    [    0,  0.125,  -0.125]
+)
+
 logger = logging.getLogger(__name__)
 
 class Scene:
@@ -60,6 +66,9 @@ class Scene:
 
         for prim in primitives:
             self.add_primitive(prim)
+
+        if 'directional_light' not in features:
+            self.enable('directional_light', DEFAULT_DIRECTIONAL_LIGHTS)
 
         for feature in features:
             config = features[feature]

--- a/plato/draw/pythreejs/Scene.py
+++ b/plato/draw/pythreejs/Scene.py
@@ -1,13 +1,8 @@
 from ... import draw
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 import rowan
 import numpy as np
 import pythreejs
-
-DEFAULT_DIRECTIONAL_LIGHTS = (
-    [ 0.4,  -0.4,    -0.4 ],
-    [-0.25, -0.0625, -0.25 ],
-    [    0,  0.125,  -0.125]
-)
 
 class Scene(draw.Scene):
     def __init__(self, *args, **kwargs):
@@ -38,9 +33,6 @@ class Scene(draw.Scene):
 
         # directly re-initialize rotation after camera has been set up
         self.rotation = kwargs.get('rotation', (1, 0, 0, 0))
-
-        # Enable default directional lights so particles don't appear black
-        self.enable('directional_light', value=DEFAULT_DIRECTIONAL_LIGHTS)
 
     @property
     def zoom(self):

--- a/plato/draw/vispy/ConvexPolyhedra.py
+++ b/plato/draw/vispy/ConvexPolyhedra.py
@@ -1,9 +1,10 @@
 import itertools
 import numpy as np
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/ConvexSpheropolyhedra.py
+++ b/plato/draw/vispy/ConvexSpheropolyhedra.py
@@ -1,9 +1,10 @@
 import itertools
 import numpy as np
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/Ellipsoids.py
+++ b/plato/draw/vispy/Ellipsoids.py
@@ -1,10 +1,11 @@
 import itertools
 import numpy as np
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from .Spheres import Spheres
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/Mesh.py
+++ b/plato/draw/vispy/Mesh.py
@@ -2,9 +2,10 @@ from collections import defaultdict
 import itertools
 import numpy as np
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/Scene.py
+++ b/plato/draw/vispy/Scene.py
@@ -2,7 +2,7 @@ import vispy.io
 from .Canvas import Canvas
 from ... import draw
 import numpy as np
-from .internal import DEFAULT_DIRECTIONAL_LIGHTS
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 
 def set_orthographic_projection(camera, left, right, bottom, top, near, far):
     camera[:] = 0
@@ -82,7 +82,16 @@ class Scene(draw.Scene):
         for feature in list(self.enabled_features):
             self.enable(feature, **self.get_feature_config(feature))
 
-    def enable(self, name, **parameters):
+    def enable(self, name, auto_value=None, **parameters):
+        """Enable an optional rendering feature.
+
+        :param name: Name of the feature to enable
+        :param auto_value: Shortcut for features with single-value configuration. If given as a positional argument, will be given the default configuration name 'value'.
+        :param parameters: Keyword arguments specifying additional configuration options for the given feature
+        """
+        if auto_value is not None:
+            parameters['value'] = auto_value
+
         if name == 'directional_light':
             lights = parameters.get('value', DEFAULT_DIRECTIONAL_LIGHTS)
             lights = np.atleast_2d(lights).astype(np.float32)

--- a/plato/draw/vispy/SphereUnions.py
+++ b/plato/draw/vispy/SphereUnions.py
@@ -2,9 +2,10 @@ import itertools
 import numpy as np
 from ... import geometry
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/Spheres.py
+++ b/plato/draw/vispy/Spheres.py
@@ -1,9 +1,10 @@
 import itertools
 import numpy as np
 from ... import mesh
-from .internal import GLPrimitive, GLShapeDecorator, DEFAULT_DIRECTIONAL_LIGHTS
+from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 from vispy import gloo
 
 @GLShapeDecorator

--- a/plato/draw/vispy/internal.py
+++ b/plato/draw/vispy/internal.py
@@ -5,14 +5,9 @@ import vispy, vispy.app
 from vispy import gloo
 from ... import mesh
 from ..internal import array_size_checkers, ATTRIBUTE_DOCSTRING_TEMPLATE
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 
 ATTRIBUTE_DOCSTRING_HEADER = '\n\nThis primitive has the following opengl-specific attributes:'
-
-DEFAULT_DIRECTIONAL_LIGHTS = (
-    [ 0.4,  -0.4,    -0.4 ],
-    [-0.25, -0.0625, -0.25 ],
-    [    0,  0.125,  -0.125]
-)
 
 class GLPrimitive:
     def __init__(self):


### PR DESCRIPTION
This fixes #27 by enabling `directional_light` in the base `Scene` constructor.