### PR TITLE
Add static rendering feature to vispy scenes

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -69,6 +69,7 @@ Contents:
    povray
    pythreejs
    vispy
+   zdog
    troubleshooting
 
 Indices and tables

--- a/doc/source/zdog.rst
+++ b/doc/source/zdog.rst
@@ -1,0 +1,22 @@
+Zdog Backend
+============
+
+.. automodule:: plato.draw.zdog
+
+.. autoclass:: Scene
+   :members:
+
+3D Graphics Primitives
+----------------------
+
+.. autoclass:: ConvexPolyhedra
+   :members:
+
+.. autoclass:: ConvexSpheropolyhedra
+   :members:
+
+.. autoclass:: Lines
+   :members:
+
+.. autoclass:: Spheres
+   :members:

--- a/examples/zdog test scenes.ipynb
+++ b/examples/zdog test scenes.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plato\n",
+    "import plato.draw.zdog as draw\n",
+    "import IPython\n",
+    "import sys; sys.path.append('../test')\n",
+    "import test_scenes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "for (name, scene) in test_scenes.translate_usable_scenes(draw):\n",
+    "    IPython.display.display(IPython.display.Markdown('# {}'.format(name)))\n",
+    "    IPython.display.display(scene.show())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/plato/draw/ConvexPolyhedra.py
+++ b/plato/draw/ConvexPolyhedra.py
@@ -18,4 +18,6 @@ class ConvexPolyhedra(Shape):
          'Color, RGBA, [0, 1] for each particle'),
         ('vertices', np.float32, (0, 0, 0), 2, False,
          'Vertices in local coordinates for the shape, to be replicated for each particle'),
+        ('outline', np.float32, 0, 0, False,
+         'Outline width for all shapes'),
         ]))

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -41,8 +41,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
 
                 light = ambient_light
                 for light_direction in directional_light:
-                    light += -np.dot(light_direction, normal)
-                light = max(0, light)
+                    light += max(0, -np.dot(light_direction, normal))
 
                 lit_color = color.copy()
                 lit_color[:3] *= light

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -2,15 +2,14 @@ import numpy as np
 from ... import math
 from ... import geometry
 from ... import draw
-from matplotlib.collections import PatchCollection
-from matplotlib.path import Path
-from matplotlib.patches import PathPatch, Polygon
+from .internal import PatchUser
+from matplotlib.patches import Polygon
 from matplotlib.transforms import Affine2D
 
-class ConvexPolyhedra(draw.ConvexPolyhedra):
+class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
     __doc__ = draw.ConvexPolyhedra.__doc__
 
-    def render(self, axes, aa_pixel_size=0, rotation=(1, 0, 0, 0),
+    def _render_patches(self, axes, aa_pixel_size=0, rotation=(1, 0, 0, 0),
                ambient_light=0, directional_light=(-.1, -.25, -1), **kwargs):
         rotation = np.asarray(rotation)
         directional_light = np.atleast_2d(directional_light)
@@ -52,9 +51,6 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
 
                 patches.append(Polygon(face_verts[:, :2], closed=True, zorder=-z))
                 colors.append(lit_color)
-        patches = PatchCollection(patches)
-        patches.set_facecolor(np.clip(colors, 0, 1))
-        collections.append(patches)
 
-        for collection in collections:
-            axes.add_collection(collection)
+        colors = np.clip(colors, 0, 1)
+        return [(patches, colors)]

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -49,7 +49,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
 
                 face_verts[:, :2] += np.sign(face_verts[:, :2])*aa_pixel_size
 
-                patches.append(Polygon(face_verts[:, :2], closed=True, zorder=-z))
+                patches.append(Polygon(face_verts[:, :2], closed=True, zorder=z))
                 colors.append(lit_color)
 
         colors = np.clip(colors, 0, 1)

--- a/plato/draw/matplotlib/DiskUnions.py
+++ b/plato/draw/matplotlib/DiskUnions.py
@@ -1,14 +1,14 @@
 import numpy as np
 from ... import draw
-from matplotlib.patches import Circle, Wedge, Polygon
-from matplotlib.collections import PatchCollection
+from .internal import PatchUser
+from matplotlib.patches import Circle, Wedge
 from matplotlib.transforms import Affine2D
 
-class DiskUnions(draw.DiskUnions):
+class DiskUnions(draw.DiskUnions, PatchUser):
     __doc__ = draw.DiskUnions.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
 
         outline = self.outline
         points = self.points
@@ -23,11 +23,13 @@ class DiskUnions(draw.DiskUnions):
                 tf = Affine2D().scale(scale).rotate(angle).translate(*position)
                 for i in range(len(self.points)):
                     patches.append(Wedge(points[i], radii[i], 0, 360, width=outline, transform=tf))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+            outline_colors = np.tile(outline_colors, (len(self.positions), 1))
+
+            # in case the user gave inconsistent numbers of positions/angles/colors
+            N = min(len(patches), len(outline_colors))
+            result.append((patches[:N], outline_colors[:N]))
         else:
             aa_pixel_size = 0
 
@@ -38,10 +40,8 @@ class DiskUnions(draw.DiskUnions):
             tf = Affine2D().scale(scale).rotate(angle).translate(*position)
             for i in range(len(self.points)):
                 patches.append(Circle(points[i], radius=shifted_radii[i], transform=tf))
+        colors = np.tile(self.colors, (len(self.positions), 1))
+        N = min(len(patches), len(colors))
+        result.append((patches[:N], colors[:N]))
 
-        patches = PatchCollection(patches)
-        collections.append(patches)
-        patches.set_facecolor(self.colors)
-
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/Disks.py
+++ b/plato/draw/matplotlib/Disks.py
@@ -1,24 +1,22 @@
 import numpy as np
 from ... import draw
+from .internal import PatchUser
 from matplotlib.patches import Circle, Wedge
-from matplotlib.collections import PatchCollection
 
-class Disks(draw.Disks):
+class Disks(draw.Disks, PatchUser):
     __doc__ = draw.Disks.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
         outline = self.outline
 
         if outline > 0:
             patches = []
             for (position, radius) in zip(self.positions, self.radii):
                 patches.append(Wedge(position, radius, 0, 360, width=outline))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+            result.append((patches, outline_colors))
         else:
             aa_pixel_size = 0
 
@@ -27,9 +25,6 @@ class Disks(draw.Disks):
         patches = []
         for (position, radius) in zip(self.positions, shifted_radii):
             patches.append(Circle(position, radius))
-        patches = PatchCollection(patches)
-        patches.set_facecolor(self.colors)
-        collections.append(patches)
+        result.append((patches, self.colors))
 
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/Polygons.py
+++ b/plato/draw/matplotlib/Polygons.py
@@ -17,11 +17,8 @@ class Polygons(draw.Polygons, PatchUser):
         scale_factors = np.linalg.norm(self.orientations, axis=-1)**2
 
         if self.outline > 0:
-            tessellation = geometry.Polygon(self.vertices)
-            outline = geometry.Outline(tessellation, self.outline)
-
             outer_vertices = vertices
-            vertices = outline.inner.vertices
+            vertices = geometry.insetPolygon(vertices, self.outline)
 
             commands = [Path.MOVETO] + (vertices.shape[0] - 1)*[Path.LINETO] + [Path.CLOSEPOLY]
             commands = 2*commands

--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -72,11 +72,12 @@ class Scene(draw.Scene):
 
         all_colors = np.concatenate(all_colors, axis=0)
 
-        collection = PatchCollection(all_patches)
-        collection.set_facecolor(all_colors)
+        sort_indices = np.argsort([patch.zorder for patch in all_patches])
+        collection = PatchCollection([all_patches[i] for i in sort_indices])
+        collection.set_facecolor(all_colors[sort_indices])
+        axes.add_collection(collection)
 
         patches.clear()
-        axes.add_collection(collection)
 
     def show(self, figure=None, axes=None):
         """Render and show the shapes in this Scene.

--- a/plato/draw/matplotlib/Spheropolygons.py
+++ b/plato/draw/matplotlib/Spheropolygons.py
@@ -2,16 +2,16 @@ import numpy as np
 from ... import math
 from ... import geometry
 from ... import draw
-from matplotlib.collections import PatchCollection
+from .internal import PatchUser
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
 
-class Spheropolygons(draw.Spheropolygons):
+class Spheropolygons(draw.Spheropolygons, PatchUser):
     __doc__ = draw.Spheropolygons.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
 
         vertices = self.vertices
         # distance vector from each vertex to the next vertex in a given shape
@@ -67,11 +67,10 @@ class Spheropolygons(draw.Spheropolygons):
             for (position, angle) in zip(self.positions, self.angles):
                 tf = Affine2D().rotate(angle).translate(*position)
                 patches.append(PathPatch(path.transformed(tf)))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+
+            result.append((patches, outline_colors))
 
             vertices += np.sign(vertices)*aa_pixel_size
 
@@ -95,9 +94,6 @@ class Spheropolygons(draw.Spheropolygons):
         for (position, angle) in zip(self.positions, self.angles):
             tf = Affine2D().rotate(angle).translate(*position)
             patches.append(PathPatch(path.transformed(tf)))
-        patches = PatchCollection(patches)
-        patches.set_facecolor(self.colors)
-        collections.append(patches)
+        result.append((patches, self.colors))
 
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/internal.py
+++ b/plato/draw/matplotlib/internal.py
@@ -1,0 +1,19 @@
+from matplotlib.collections import PatchCollection
+import numpy as np
+
+class PatchUser:
+    def render(self, axes, **kwargs):
+        patches = self._render_patches(axes, **kwargs)
+
+        all_patches = []
+        all_colors = []
+        for (p, c) in patches:
+            all_patches.extend(p)
+            all_colors.append(c)
+
+        all_colors = np.concatenate(all_colors, axis=0)
+
+        collection = PatchCollection(all_patches)
+        collection.set_facecolor(all_colors)
+
+        axes.add_collection(collection)

--- a/plato/draw/pythreejs/ConvexPolyhedra.py
+++ b/plato/draw/pythreejs/ConvexPolyhedra.py
@@ -17,10 +17,10 @@ class ConvexPolyhedra(draw.ConvexPolyhedra, ThreeJSPrimitive):
             vertices = np.concatenate([vertices,
                 [(-1, -1, -1), (1, 1, -1), (1, -1, 1), (-1, 1, 1)]], axis=0)
 
-        (image, normal, indices, _) = mesh.convexPolyhedronMesh(vertices)
+        poly_mesh = mesh.convexPolyhedronMesh(vertices)
         (positions, orientations, colors, images, normals) = mesh.unfoldProperties(
             [self.positions, self.orientations, self.colors],
-            [image, normal])
+            [poly_mesh.image, poly_mesh.normal])
 
         self._finalize_primitive_arrays(
-            positions, orientations, colors, images, normals, indices)
+            positions, orientations, colors, images, normals, poly_mesh.indices)

--- a/plato/draw/vispy/Canvas.py
+++ b/plato/draw/vispy/Canvas.py
@@ -495,7 +495,7 @@ class Canvas(vispy.app.Canvas):
                 gloo.set_blend_func('one', 'one', 'zero', 'one')
                 gloo.set_blend_equation('func_reverse_subtract')
             else:
-                clear_color = (0, 0, 0, 0)
+                clear_color = (0, 0, 0, 1)
                 gloo.set_state(preset='additive',
                                depth_test=False,
                                blend=True,

--- a/plato/draw/zdog/ConvexPolyhedra.py
+++ b/plato/draw/zdog/ConvexPolyhedra.py
@@ -1,0 +1,11 @@
+from ... import draw
+from .internal import PolyhedronRenderer
+
+class ConvexPolyhedra(draw.ConvexPolyhedra, PolyhedronRenderer):
+    __doc__ = draw.ConvexPolyhedra.__doc__
+
+    def render(self, *args, **kwargs):
+        if self.outline:
+            kwargs['outline'] = self.outline
+        kwargs['stroke'] = False
+        return PolyhedronRenderer.render(self, *args, **kwargs)

--- a/plato/draw/zdog/ConvexSpheropolyhedra.py
+++ b/plato/draw/zdog/ConvexSpheropolyhedra.py
@@ -1,0 +1,9 @@
+from ... import draw
+from .internal import PolyhedronRenderer
+
+class ConvexSpheropolyhedra(draw.ConvexSpheropolyhedra, PolyhedronRenderer):
+    __doc__ = draw.ConvexSpheropolyhedra.__doc__
+
+    def render(self, *args, **kwargs):
+        kwargs['stroke'] = self.radius*2
+        return PolyhedronRenderer.render(self, *args, **kwargs)

--- a/plato/draw/zdog/Lines.py
+++ b/plato/draw/zdog/Lines.py
@@ -1,0 +1,39 @@
+import numpy as np
+import rowan
+from ... import draw
+from ... import mesh as pmesh
+from ... import geometry
+from ... import math as pmath
+
+class Lines(draw.Lines):
+    __doc__ = draw.Lines.__doc__
+
+    def render(self, rotation=(1, 0, 0, 0), name_suffix='', illo_id='illo',
+               ambient_light=0.4, directional_light=[], **kwargs):
+        # in the zdog coordinate system, x is to the right, y is down,
+        # and z is toward you
+        lines = []
+
+        particles = zip(
+            self.start_points*(1, -1, 1), self.end_points*(1, -1, 1),
+            self.widths, self.colors*255)
+        for i, (start, end, width, color) in enumerate(particles):
+            path = ', '.join('{{x: {}, y: {}, z: {}}}'.format(*v) for v in [start, end])
+
+            (r, g, b) = map(int, color[:3])
+
+            # RGB components are 0-255, A component is a float 0-1
+            color_str = '"rgba({}, {}, {}, {})"'.format(r, g, b, color[3]/255)
+
+            lines.append("""
+            new Zdog.Shape({{
+                addTo: {illo_id},
+                color: {color},
+                path: [{path}],
+                stroke: {width},
+                closed: false,
+            }});
+            """.format(
+                illo_id=illo_id, color=color_str, path=path, width=width))
+
+        return lines

--- a/plato/draw/zdog/Scene.py
+++ b/plato/draw/zdog/Scene.py
@@ -1,0 +1,107 @@
+from ... import draw
+from ... import math
+import numpy as np
+import rowan
+
+class Scene(draw.Scene):
+    __doc__ = draw.Scene.__doc__ + """
+    This Scene supports the following features:
+
+    * *ambient_light*: Enable trivial ambient lighting. The given value indicates the magnitude of the light (in [0, 1]).
+    * *directional_light*: Add directional lights. The given value indicates the magnitude*direction normal vector.
+    """
+
+    CANVAS_INDEX = 0
+
+    def render(self):
+        """Render all the shapes in this scene.
+
+        :returns: HTML string contents to be displayed
+        """
+        canvas_id = 'zdog_{}'.format(self.CANVAS_INDEX)
+        illo_id = 'illo_{}'.format(self.CANVAS_INDEX)
+        Scene.CANVAS_INDEX += 1
+
+        html_lines = []
+
+        js_lines = []
+
+        euler = -rowan.to_euler(
+            self.rotation, convention='xyz', axis_type='intrinsic')
+        translation = self.translation*(1, -1, 1)
+
+        js_lines.append("""
+        let {illo_id} = new Zdog.Illustration({{
+            element: '#{canvas_id}',
+            zoom: {zoom},
+            dragRotate: true,
+            rotate: {{x: {angle[0]}, y: {angle[1]}, z: {angle[2]}}},
+            translate: {{x: {pos[0]}, y: {pos[1]}, z: {pos[2]}}},
+        }});
+        """.format(
+            illo_id=illo_id, canvas_id=canvas_id, zoom=self.zoom*self.pixel_scale,
+            angle=euler, pos=translation))
+
+        config = self.get_feature_config('ambient_light')
+        ambient_light = 0 if config is None else config.get('value', .4)
+
+        config = self.get_feature_config('directional_light')
+        directional_light = ([(0, 0, 0)] if config is None else
+                             config.get('value', [(0, 0, 0)]))
+        directional_light = np.atleast_2d(directional_light)
+
+        shapeIndex = 0
+        for i, prim in enumerate(self._primitives):
+            js_lines.extend(prim.render(
+                rotation=self.rotation, illo_id=illo_id,
+                name_suffix=i, ambient_light=ambient_light,
+                directional_light=directional_light))
+
+        (width, height) = map(int, self.size_pixels)
+        html_lines.append("""
+        <canvas id="{canvas_id}" width="{width}" height="{height}"></canvas>
+        """.format(canvas_id=canvas_id, width=width, height=height))
+
+        html_lines.append("""<script>
+            var fill_{canvas_id} = function() {{
+            """.format(canvas_id=canvas_id))
+        html_lines.extend(js_lines)
+        html_lines.append("""
+            let animate_{canvas_id} = function() {{
+                {illo_id}.updateRenderGraph();
+                requestAnimationFrame(animate_{canvas_id});
+            }};
+            animate_{canvas_id}();""".format(canvas_id=canvas_id, illo_id=illo_id))
+        # remove the global reference to this function after using it
+        html_lines.append('fill_{canvas_id} = null;'.format(canvas_id=canvas_id))
+        html_lines.append('};') # end of fill_{canvas_id}
+        # now call fill_{canvas_id}, possibly after loading zdog
+        html_lines.append("""
+            if (typeof Zdog == 'undefined')
+            {{
+                var script = document.createElement('script');
+                script.addEventListener('load', fill_{canvas_id}, false);
+                script.src = 'https://unpkg.com/zdog@1/dist/zdog.dist.min.js';
+                document.getElementsByTagName('head')[0].appendChild(script);
+            }}
+            else
+                fill_{canvas_id}();
+            """.format(canvas_id=canvas_id))
+        html_lines.append('</script>')
+
+        return '\n'.join(html_lines)
+
+    def show(self):
+        """Render the scene to an image and display using ipython."""
+        import IPython.display
+        return IPython.display.HTML(self.render())
+
+    def save(self, filename):
+        """Save the scene, either as povray source or a rendered image.
+
+        :param filename: target filename to save the result into
+        """
+        result = self.render()
+
+        with open(filename, 'w') as f:
+            f.write(result)

--- a/plato/draw/zdog/Spheres.py
+++ b/plato/draw/zdog/Spheres.py
@@ -1,0 +1,87 @@
+import collections
+import itertools
+import numpy as np
+from ... import draw
+from ...draw import internal
+
+LightInfo = collections.namedtuple(
+    'LightInfo', ['normal', 'magnitude'])
+
+@internal.ShapeDecorator
+class Spheres(draw.Spheres):
+    __doc__ = draw.Spheres.__doc__
+
+    _ATTRIBUTES = draw.Spheres._ATTRIBUTES + list(itertools.starmap(
+        internal.ShapeAttribute, [
+            ('light_levels', np.uint32, 3, 0, False,
+             'Number of quantized light levels to use'),
+        ]))
+
+    def render(self, rotation=(1, 0, 0, 0), name_suffix='', illo_id='illo',
+               ambient_light=0.4, directional_light=[], **kwargs):
+        # in the zdog coordinate system, x is to the right, y is down,
+        # and z is toward you
+        lines = []
+
+        light_levels = np.linspace(0, 1, self.light_levels + 2)[1:-1]
+
+        directional_light = np.atleast_2d(directional_light)
+
+        light_info = []
+        for light in directional_light:
+            mag = np.linalg.norm(light)
+            normal = light/mag
+
+            light_info.append(LightInfo(normal, mag))
+
+        particles = zip(
+            self.positions*(1, -1, 1), self.diameters, self.colors*255)
+        for i, (position, diameter, color) in enumerate(particles):
+            group_index = 'sphere_{}_{}'.format(name_suffix, i)
+
+            lines.append("""
+            let {group_index} = new Zdog.Group({{
+                addTo: {illo_id},
+                translate: {{x: {pos[0]}, y: {pos[1]}, z: {pos[2]}}},
+                updateSort: true,
+            }});""".format(
+                group_index=group_index, illo_id=illo_id, pos=position))
+
+            (r, g, b) = map(int, ambient_light*color[:3])
+            color_str = '"rgba({}, {}, {}, {})"'.format(r, g, b, color[3]/255)
+
+            lines.append("""
+            new Zdog.Shape({{
+                addTo: {group_index},
+                stroke: {diameter},
+                color: {color},
+            }});""".format(group_index=group_index, pos=position,
+                           diameter=diameter, color=color_str))
+
+            for (light, level_fraction) in itertools.product(
+                    light_info, light_levels):
+                offset = -0.5*diameter*(1 - level_fraction)*light.normal*(1, -1, 1)
+
+                this_color = color.copy()
+                light_level = 1 - level_fraction
+                this_color[:3] *= ambient_light + light_level*light.magnitude
+                this_color.clip(0, 255, this_color)
+
+                (r, g, b) = map(int, this_color[:3])
+
+                # RGB components are 0-255, A component is a float 0-1
+                color_str = '"rgba({}, {}, {}, {})"'.format(r, g, b, color[3]/255)
+
+                lines.append("""
+                new Zdog.Shape({{
+                    addTo: {group_index},
+                    translate: {{x: {pos[0]}, y: {pos[1]}, z: {pos[2]}}},
+                    color: {color},
+                    stroke: {diameter},
+                    fill: true,
+                }});
+                """.format(
+                    group_index=group_index, pos=offset,
+                    diameter=diameter*level_fraction, color=color_str))
+
+        return lines

--- a/plato/draw/zdog/__init__.py
+++ b/plato/draw/zdog/__init__.py
@@ -1,0 +1,14 @@
+"""
+The zdog backend uses `zdog <https://zzz.dog>`_ to render
+shapes. Zdog is an HTML canvas-based engine that works best for
+simple, cartoon-style illustrations. Plato's version works inside
+notebook environments and also supports rendering standalone HTML for
+inclusion in other pages.
+"""
+
+from .Scene import Scene
+
+from .ConvexPolyhedra import ConvexPolyhedra
+from .ConvexSpheropolyhedra import ConvexSpheropolyhedra
+from .Lines import Lines
+from .Spheres import Spheres

--- a/plato/draw/zdog/internal.py
+++ b/plato/draw/zdog/internal.py
@@ -1,0 +1,96 @@
+import numpy as np
+import rowan
+from ... import mesh as pmesh
+from ... import geometry
+
+class PolyhedronRenderer:
+    def render(self, rotation=(1, 0, 0, 0), name_suffix='', illo_id='illo',
+               ambient_light=0.4, directional_light=[], stroke=False,
+               outline=False, **kwargs):
+
+        # in the zdog coordinate system, x is to the right, y is down,
+        # and z is toward you
+        lines = []
+
+        stroke = stroke or 'false'
+
+        (vertices, faces) = geometry.convexHull(self.vertices)
+
+        face_normals = []
+        face_paths = []
+        for face in faces:
+            r01 = vertices[face[1]] - vertices[face[0]]
+            r12 = vertices[face[2]] - vertices[face[1]]
+            normal = np.cross(r01, r12)
+            normal /= np.linalg.norm(normal)
+            face_normals.append(normal)
+
+            path = ', '.join('{{x: {}, y: {}, z: {}}}'.format(*v) for v in vertices[face]*(1, -1, 1))
+            face_paths.append(path)
+        face_normals = np.array(face_normals, dtype=np.float32)
+
+        orientations_euler = rowan.to_euler(
+            self.orientations, convention='xyz', axis_type='intrinsic')
+
+        particles = zip(
+            self.positions*(1, -1, 1), self.orientations,
+            -orientations_euler, self.colors*255)
+        for i, (position, orientation, eulers, color) in enumerate(particles):
+            group_index = 'convexPoly_{}_{}'.format(name_suffix, i)
+
+            # full rotation to apply to vectors from base orientation
+            # to final scene orientation
+            full_rotation = rowan.multiply(rotation, orientation)
+
+            lines.append("""
+            let {group_index} = new Zdog.Group({{
+                addTo: {illo_id},
+                rotate: {{x: {angle[0]}, y: {angle[1]}, z: {angle[2]}}},
+                translate: {{x: {pos[0]}, y: {pos[1]}, z: {pos[2]}}},
+                updateSort: true,
+            }});""".format(
+                group_index=group_index, illo_id=illo_id, angle=eulers,
+                pos=position))
+
+            for (face_path, normal) in zip(face_paths, face_normals):
+                rotated_normal = rowan.rotate(full_rotation, normal)
+
+                light = 0
+                for direction in directional_light:
+                    light += max(0, -np.dot(rotated_normal, direction))
+                light = np.clip(light, 0, 1)
+                light += ambient_light
+
+                (r, g, b) = map(int, light*color[:3])
+
+                # RGB components are 0-255, A component is a float 0-1
+                face_color = '"rgba({}, {}, {}, {})"'.format(r, g, b, color[3]/255)
+
+                lines.append("""
+                new Zdog.Shape({{
+                    addTo: {group_index},
+                    color: {face_color},
+                    path: [{path}],
+                    fill: true,
+                    backface: true,
+                    stroke: {stroke},
+                }});
+                """.format(
+                    group_index=group_index, face_color=face_color, path=face_path,
+                    stroke=stroke))
+
+                if outline:
+                    outline_color = '"rgba(0, 0, 0, {})"'.format(color[3]/255)
+                    lines.append("""
+                    new Zdog.Shape({{
+                        addTo: {group_index},
+                        color: {color},
+                        path: [{path}],
+                        fill: false,
+                        stroke: {stroke},
+                    }});
+                    """.format(
+                        group_index=group_index, color=outline_color, path=face_path,
+                        stroke=outline))
+
+        return lines

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name='plato-draw',
           'plato.draw.povray',
           'plato.draw.pythreejs',
           'plato.draw.vispy',
+          'plato.draw.zdog',
       ],
       project_urls={
           'Documentation': 'http://plato-draw.readthedocs.io/',

--- a/test/test_pythreejs.py
+++ b/test/test_pythreejs.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+from test_internals import get_fname
+
+from nbconvert.nbconvertapp import NbConvertApp
+
+class PythreejsTests(unittest.TestCase):
+
+    def test_notebook(self):
+        src = os.path.join(os.pardir, 'examples', 'pythreejs test scenes.ipynb')
+        fname = get_fname('pythreejs_test_scenes.html')
+
+        NbConvertApp.launch_instance(
+            argv=['--execute', '--output', fname, src])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_scenes.py
+++ b/test/test_scenes.py
@@ -509,7 +509,7 @@ def simple_cubes_octahedra(N=4):
         vertices=cube_vertices, positions=cube_positions,
         colors=cube_colors, orientations=np.ones_like(cube_colors)*(1, 0, 0, 0))
     octahedra = draw.ConvexPolyhedra(
-        vertices=oct_vertices, positions=oct_positions,
+        vertices=oct_vertices, positions=oct_positions, outline=.025,
         colors=oct_colors, orientations=np.ones_like(oct_colors)*(1, 0, 0, 0))
 
     rotation = [0.99795496,  0.01934275, -0.06089295,  0.00196485]

--- a/test/test_scenes.py
+++ b/test/test_scenes.py
@@ -140,7 +140,7 @@ def sphere_union(seed=15, num_unions=5):
     scene = draw.Scene([prim1], zoom=2, features=features, rotation=rotation)
     return scene
 
-@selectively_register_scene('matplotlib')
+@register_scene
 def colored_spheres(num_per_side=6):
     xs = np.arange(num_per_side).astype(np.float32)
     rs = np.array(list(itertools.product(*(3*[xs]))))
@@ -487,3 +487,31 @@ def field_lines(N=10):
 @register_scene
 def field_ellipsoids(N=10):
     return field_scene(N, 'ellipsoids')
+
+@register_scene
+def simple_cubes_octahedra(N=4):
+    xs = np.linspace(-N/2, N/2, N)
+    positions = np.array(list(itertools.product(xs, xs, xs)))
+
+    cube_positions = positions[::2]
+    oct_positions = positions[1::2]
+
+    cube_colors = np.ones((len(cube_positions), 4))
+    cube_colors[:] = (.5, .6, .7, 1)
+    oct_colors = np.ones((len(oct_positions), 4))
+    oct_colors[:] = (.7, .5, .6, 1)
+
+    cube_vertices = list(itertools.product(*(3*[[-.5, .5]])))
+    oct_vertices = [np.roll((0, 0, v), i) for (i, v) in
+                    itertools.product(range(3), [-.5, .5])]
+
+    cubes = draw.ConvexPolyhedra(
+        vertices=cube_vertices, positions=cube_positions,
+        colors=cube_colors, orientations=np.ones_like(cube_colors)*(1, 0, 0, 0))
+    octahedra = draw.ConvexPolyhedra(
+        vertices=oct_vertices, positions=oct_positions,
+        colors=oct_colors, orientations=np.ones_like(oct_colors)*(1, 0, 0, 0))
+
+    rotation = [0.99795496,  0.01934275, -0.06089295,  0.00196485]
+    scene = draw.Scene([cubes, octahedra], rotation=rotation, zoom=5.5)
+    return scene

--- a/test/test_zdog.py
+++ b/test/test_zdog.py
@@ -1,0 +1,21 @@
+import unittest
+import plato.draw.zdog as draw
+import test_scenes
+from test_internals import get_fname
+
+class ZdogTests(unittest.TestCase):
+
+    def render(self, scene, name=''):
+        fname = get_fname('zdog_{}.html'.format(name))
+        scene.save(fname)
+
+for i, (name, scene) in enumerate(test_scenes.translate_usable_scenes(draw)):
+    new_name = 'test_{}'.format(name)
+    setattr(
+        ZdogTests, new_name, (lambda *args, scene=scene, name=name, **kwargs:
+                                ZdogTests.render(*args, scene=scene,
+                                                   name=name)))
+    getattr(ZdogTests, new_name).__name__ = new_name
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This rendering feature automatically renders a `Scene` object offscreen and displays the image inside a jupyter notebook whenever `Scene.show()` is called, rather than displaying a webGL widget. It does require the user to select a non-jupyter backend through vispy at the start, since vispy only supports having one backend active.

Also included is a change to set the background color alpha to 1 in one case for the `additive_rendering` feature, which removes some ambiguous behavior with that feature depending on which vispy backend was selected.