### PR TITLE
Fix zorder issues in 3D matplotlib primitives

### DIFF
--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -41,8 +41,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
 
                 light = ambient_light
                 for light_direction in directional_light:
-                    light += -np.dot(light_direction, normal)
-                light = max(0, light)
+                    light += max(0, -np.dot(light_direction, normal))
 
                 lit_color = color.copy()
                 lit_color[:3] *= light

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -2,15 +2,14 @@ import numpy as np
 from ... import math
 from ... import geometry
 from ... import draw
-from matplotlib.collections import PatchCollection
-from matplotlib.path import Path
-from matplotlib.patches import PathPatch, Polygon
+from .internal import PatchUser
+from matplotlib.patches import Polygon
 from matplotlib.transforms import Affine2D
 
-class ConvexPolyhedra(draw.ConvexPolyhedra):
+class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
     __doc__ = draw.ConvexPolyhedra.__doc__
 
-    def render(self, axes, aa_pixel_size=0, rotation=(1, 0, 0, 0),
+    def _render_patches(self, axes, aa_pixel_size=0, rotation=(1, 0, 0, 0),
                ambient_light=0, directional_light=(-.1, -.25, -1), **kwargs):
         rotation = np.asarray(rotation)
         directional_light = np.atleast_2d(directional_light)
@@ -52,9 +51,6 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
 
                 patches.append(Polygon(face_verts[:, :2], closed=True, zorder=-z))
                 colors.append(lit_color)
-        patches = PatchCollection(patches)
-        patches.set_facecolor(np.clip(colors, 0, 1))
-        collections.append(patches)
 
-        for collection in collections:
-            axes.add_collection(collection)
+        colors = np.clip(colors, 0, 1)
+        return [(patches, colors)]

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -49,7 +49,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
 
                 face_verts[:, :2] += np.sign(face_verts[:, :2])*aa_pixel_size
 
-                patches.append(Polygon(face_verts[:, :2], closed=True, zorder=-z))
+                patches.append(Polygon(face_verts[:, :2], closed=True, zorder=z))
                 colors.append(lit_color)
 
         colors = np.clip(colors, 0, 1)

--- a/plato/draw/matplotlib/DiskUnions.py
+++ b/plato/draw/matplotlib/DiskUnions.py
@@ -1,14 +1,14 @@
 import numpy as np
 from ... import draw
-from matplotlib.patches import Circle, Wedge, Polygon
-from matplotlib.collections import PatchCollection
+from .internal import PatchUser
+from matplotlib.patches import Circle, Wedge
 from matplotlib.transforms import Affine2D
 
-class DiskUnions(draw.DiskUnions):
+class DiskUnions(draw.DiskUnions, PatchUser):
     __doc__ = draw.DiskUnions.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
 
         outline = self.outline
         points = self.points
@@ -23,11 +23,13 @@ class DiskUnions(draw.DiskUnions):
                 tf = Affine2D().scale(scale).rotate(angle).translate(*position)
                 for i in range(len(self.points)):
                     patches.append(Wedge(points[i], radii[i], 0, 360, width=outline, transform=tf))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+            outline_colors = np.tile(outline_colors, (len(self.positions), 1))
+
+            # in case the user gave inconsistent numbers of positions/angles/colors
+            N = min(len(patches), len(outline_colors))
+            result.append((patches[:N], outline_colors[:N]))
         else:
             aa_pixel_size = 0
 
@@ -38,10 +40,8 @@ class DiskUnions(draw.DiskUnions):
             tf = Affine2D().scale(scale).rotate(angle).translate(*position)
             for i in range(len(self.points)):
                 patches.append(Circle(points[i], radius=shifted_radii[i], transform=tf))
+        colors = np.tile(self.colors, (len(self.positions), 1))
+        N = min(len(patches), len(colors))
+        result.append((patches[:N], colors[:N]))
 
-        patches = PatchCollection(patches)
-        collections.append(patches)
-        patches.set_facecolor(self.colors)
-
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/Disks.py
+++ b/plato/draw/matplotlib/Disks.py
@@ -1,24 +1,22 @@
 import numpy as np
 from ... import draw
+from .internal import PatchUser
 from matplotlib.patches import Circle, Wedge
-from matplotlib.collections import PatchCollection
 
-class Disks(draw.Disks):
+class Disks(draw.Disks, PatchUser):
     __doc__ = draw.Disks.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
         outline = self.outline
 
         if outline > 0:
             patches = []
             for (position, radius) in zip(self.positions, self.radii):
                 patches.append(Wedge(position, radius, 0, 360, width=outline))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+            result.append((patches, outline_colors))
         else:
             aa_pixel_size = 0
 
@@ -27,9 +25,6 @@ class Disks(draw.Disks):
         patches = []
         for (position, radius) in zip(self.positions, shifted_radii):
             patches.append(Circle(position, radius))
-        patches = PatchCollection(patches)
-        patches.set_facecolor(self.colors)
-        collections.append(patches)
+        result.append((patches, self.colors))
 
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -72,11 +72,12 @@ class Scene(draw.Scene):
 
         all_colors = np.concatenate(all_colors, axis=0)
 
-        collection = PatchCollection(all_patches)
-        collection.set_facecolor(all_colors)
+        sort_indices = np.argsort([patch.zorder for patch in all_patches])
+        collection = PatchCollection([all_patches[i] for i in sort_indices])
+        collection.set_facecolor(all_colors[sort_indices])
+        axes.add_collection(collection)
 
         patches.clear()
-        axes.add_collection(collection)
 
     def show(self, figure=None, axes=None):
         """Render and show the shapes in this Scene.

--- a/plato/draw/matplotlib/Spheropolygons.py
+++ b/plato/draw/matplotlib/Spheropolygons.py
@@ -2,16 +2,16 @@ import numpy as np
 from ... import math
 from ... import geometry
 from ... import draw
-from matplotlib.collections import PatchCollection
+from .internal import PatchUser
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
 
-class Spheropolygons(draw.Spheropolygons):
+class Spheropolygons(draw.Spheropolygons, PatchUser):
     __doc__ = draw.Spheropolygons.__doc__
 
-    def render(self, axes, aa_pixel_size=0, **kwargs):
-        collections = []
+    def _render_patches(self, axes, aa_pixel_size=0, **kwargs):
+        result = []
 
         vertices = self.vertices
         # distance vector from each vertex to the next vertex in a given shape
@@ -67,11 +67,10 @@ class Spheropolygons(draw.Spheropolygons):
             for (position, angle) in zip(self.positions, self.angles):
                 tf = Affine2D().rotate(angle).translate(*position)
                 patches.append(PathPatch(path.transformed(tf)))
-            patches = PatchCollection(patches)
             outline_colors = np.zeros_like(self.colors)
             outline_colors[:, 3] = self.colors[:, 3]
-            patches.set_facecolor(outline_colors)
-            collections.append(patches)
+
+            result.append((patches, outline_colors))
 
             vertices += np.sign(vertices)*aa_pixel_size
 
@@ -95,9 +94,6 @@ class Spheropolygons(draw.Spheropolygons):
         for (position, angle) in zip(self.positions, self.angles):
             tf = Affine2D().rotate(angle).translate(*position)
             patches.append(PathPatch(path.transformed(tf)))
-        patches = PatchCollection(patches)
-        patches.set_facecolor(self.colors)
-        collections.append(patches)
+        result.append((patches, self.colors))
 
-        for collection in collections:
-            axes.add_collection(collection)
+        return result

--- a/plato/draw/matplotlib/internal.py
+++ b/plato/draw/matplotlib/internal.py
@@ -1,0 +1,19 @@
+from matplotlib.collections import PatchCollection
+import numpy as np
+
+class PatchUser:
+    def render(self, axes, **kwargs):
+        patches = self._render_patches(axes, **kwargs)
+
+        all_patches = []
+        all_colors = []
+        for (p, c) in patches:
+            all_patches.extend(p)
+            all_colors.append(c)
+
+        all_colors = np.concatenate(all_colors, axis=0)
+
+        collection = PatchCollection(all_patches)
+        collection.set_facecolor(all_colors)
+
+        axes.add_collection(collection)

--- a/test/test_scenes.py
+++ b/test/test_scenes.py
@@ -140,7 +140,7 @@ def sphere_union(seed=15, num_unions=5):
     scene = draw.Scene([prim1], zoom=2, features=features, rotation=rotation)
     return scene
 
-@selectively_register_scene('matplotlib')
+@register_scene
 def colored_spheres(num_per_side=6):
     xs = np.arange(num_per_side).astype(np.float32)
     rs = np.array(list(itertools.product(*(3*[xs]))))
@@ -487,3 +487,31 @@ def field_lines(N=10):
 @register_scene
 def field_ellipsoids(N=10):
     return field_scene(N, 'ellipsoids')
+
+@register_scene
+def simple_cubes_octahedra(N=4):
+    xs = np.linspace(-N/2, N/2, N)
+    positions = np.array(list(itertools.product(xs, xs, xs)))
+
+    cube_positions = positions[::2]
+    oct_positions = positions[1::2]
+
+    cube_colors = np.ones((len(cube_positions), 4))
+    cube_colors[:] = (.5, .6, .7, 1)
+    oct_colors = np.ones((len(oct_positions), 4))
+    oct_colors[:] = (.7, .5, .6, 1)
+
+    cube_vertices = list(itertools.product(*(3*[[-.5, .5]])))
+    oct_vertices = [np.roll((0, 0, v), i) for (i, v) in
+                    itertools.product(range(3), [-.5, .5])]
+
+    cubes = draw.ConvexPolyhedra(
+        vertices=cube_vertices, positions=cube_positions,
+        colors=cube_colors, orientations=np.ones_like(cube_colors)*(1, 0, 0, 0))
+    octahedra = draw.ConvexPolyhedra(
+        vertices=oct_vertices, positions=oct_positions,
+        colors=oct_colors, orientations=np.ones_like(oct_colors)*(1, 0, 0, 0))
+
+    rotation = [0.99795496,  0.01934275, -0.06089295,  0.00196485]
+    scene = draw.Scene([cubes, octahedra], rotation=rotation, zoom=5.5)
+    return scene


### PR DESCRIPTION
Previously, having multiple primitives (i.e. two `ConvexPolyhedra` objects, or a `ConvexPolyhedra` and `Spheres`) would cause the shapes for each primitive to be drawn in order, ignoring proper depth ordering. This patch merges these primitives into a single `PatchCollection`.