### PR TITLE
Improve vispy docs

### DIFF
--- a/plato/draw/vispy/Canvas.py
+++ b/plato/draw/vispy/Canvas.py
@@ -619,12 +619,6 @@ class Canvas(vispy.app.Canvas):
             self._selection_callback = None
             callback(self._mouse_origin, event.pos)
 
-    def on_key_press(self, event):
-        if event.key == 'X' or event.key == 'Y' or event.key == 'Z':
-            self._mouse_origin = np.array([0, 0], dtype=np.float32)
-            self._scene.translation = (0, 0, 0)
-            self.update()
-
     def _mouse_translate(self, delta):
         scale = 2/np.array(self._scene.size_pixels)/self._scene.camera[[0, 1], [0, 1]]*[1, -1]
         translation = self._scene.translation

--- a/plato/draw/vispy/Canvas.py
+++ b/plato/draw/vispy/Canvas.py
@@ -666,12 +666,16 @@ class Canvas(vispy.app.Canvas):
             self.updateRotation(event, delta=(0, -np.pi/36))
         elif event.key == 'K':
             self.updateRotation(event, delta=(0, np.pi/36))
-        elif event.key == 'X' or event.key == 'Y' or event.key == 'Z':
+        elif event.key == 'X':
+            # rotate about y axis by -pi/2
+            rot = [np.cos(-np.pi/4), 0, np.sin(-np.pi/4), 0]
+            self._scene.rotation = np.asarray(rot, dtype=np.float32)
+        elif event.key == 'Y':
+            # rotate about x axis by pi/2
+            rot = [np.cos(np.pi/4), np.sin(np.pi/4), 0, 0]
+            self._scene.rotation = np.asarray(rot, dtype=np.float32)
+        elif event.key == 'Z':
             self._scene.rotation = np.asarray([1., 0., 0., 0.], dtype=np.float32)
-            if event.key == 'Y':
-                self.updateRotation(event, delta=(0, -np.pi/6), suppress=True)
-            elif event.key == 'Z':
-                self.updateRotation(event, delta=(-np.pi/6, 0), suppress=True)
         self.update()
 
     def grab_selection_area(self, callback):

--- a/plato/draw/vispy/__init__.py
+++ b/plato/draw/vispy/__init__.py
@@ -31,8 +31,8 @@ the scene by default.
 camera via the keyboard. Control or meta in conjunction with the arrow
 keys rotate the system in 15 degree increments. The same functionality
 is mapped to the I (up), J (left), K (down), and L (right) keys. X, Y,
-and Z directly snap the scene to look down the z axis, the y axis, or
-the x axis, respectively.
+and Z directly snap the scene to look down the x, y, or z axes,
+respectively.
 """
 
 from .Scene import Scene

--- a/plato/draw/vispy/__init__.py
+++ b/plato/draw/vispy/__init__.py
@@ -18,6 +18,21 @@ calling `Scene.show()`::
   scene.show()
   vispy.app.run()
 
+**Mouse controls:** Live vispy windows support rotating the scene in
+three dimensions by dragging the mouse. Dragging while holding the
+control or meta keys causes the mouse movement to rotate the scene
+about the z axis and zoom in or out. Holding the alt key while
+dragging the mouse cursor will translate the scene; for
+two-dimensional scenes, it may be preferable to enable the `pan`
+feature, which causes mouse motion to translate, rather than rotate,
+the scene by default.
+
+**Keyboard controls:** Live vispy windows also support controlling the
+camera via the keyboard. Control or meta in conjunction with the arrow
+keys rotate the system in 15 degree increments. The same functionality
+is mapped to the I (up), J (left), K (down), and L (right) keys. X, Y,
+and Z directly snap the scene to look down the z axis, the y axis, or
+the x axis, respectively.
 """
 
 from .Scene import Scene


### PR DESCRIPTION
I added some notes about keyboard and mouse shortcuts. I'm wondering if we should change the x/y/z key behavior to not be so illogical? One sensible way would be to have 'z' look down the z axis (default view), 'x' look down the x axis, and 'y' look down the y axis.