### PR TITLE
Add imperative API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
               xvfb-run -a -s "-screen 0 1600x1200x24 +extension GLX +render +iglx" python3 -m nose --with-xunit --xunit-file=/tmp/test_results/plato/results.xml
           environment:
               PLATO_TEST_ARTIFACT_DIR: /tmp/plato_output
+              VISPY_TEST_BACKEND: pyglet
 
       - store_artifacts:
           path: /tmp/plato_output

--- a/doc/source/imperative.rst
+++ b/doc/source/imperative.rst
@@ -1,0 +1,9 @@
+==============
+Imperative API
+==============
+
+.. automodule:: plato.imp
+   :members: clear, get, show, arrows2D, box, convex_polyhedra,
+             convex_spheropolyhedra, disks, disk_unions, ellipsoids,
+             lines, mesh, polygons, sphere_points, spheres,
+             sphere_unions, spheropolygons, voronoi

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -71,6 +71,7 @@ Contents:
    pythreejs
    vispy
    zdog
+   imperative
    troubleshooting
 
 Indices and tables

--- a/doc/source/primitives.rst
+++ b/doc/source/primitives.rst
@@ -30,6 +30,9 @@ be used, for example::
   scene = draw.Scene(disks, ...)
   scene.show()
 
+.. note:: For quick and simple visualizations, the imperative
+          :py:mod:`plato.imp` module may be easier.
+
 Base Drawing Module
 ===================
 

--- a/plato/__init__.py
+++ b/plato/__init__.py
@@ -2,5 +2,6 @@ from .version import __version__
 from . import cmap
 from . import draw
 from . import geometry
+from . import imp
 from . import math
 from . import mesh

--- a/plato/draw/Scene.py
+++ b/plato/draw/Scene.py
@@ -87,6 +87,9 @@ class Scene:
         for prim in self._primitives:
             yield prim
 
+    def __len__(self):
+        return len(self._primitives)
+
     @property
     def translation(self):
         """(x, y, z) translation to be applied to the scene as a whole after rotating.

--- a/plato/draw/fresnel/Scene.py
+++ b/plato/draw/fresnel/Scene.py
@@ -110,3 +110,6 @@ class Scene(draw.Scene):
             render_function = tracer.render
 
         self._output = render_function(self._fresnel_scene)
+
+    def _ipython_display_(self):
+        return self.show()

--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -95,3 +95,6 @@ class Scene(draw.Scene):
         """
         (figure, _) = self.render()
         return figure.savefig(filename, dpi=figure.dpi)
+
+    def _ipython_display_(self):
+        return self.show()

--- a/plato/draw/povray/Scene.py
+++ b/plato/draw/povray/Scene.py
@@ -176,3 +176,9 @@ class Scene(draw.Scene):
             return subprocess.check_call(command)
         finally:
             os.remove(povfile)
+
+    def _repr_png_(self):
+        with tempfile.NamedTemporaryFile(suffix='.png') as temp:
+            self.save(temp.name)
+            with open(temp.name, 'rb') as f:
+                return f.read()

--- a/plato/draw/pythreejs/Scene.py
+++ b/plato/draw/pythreejs/Scene.py
@@ -181,3 +181,6 @@ class Scene(draw.Scene):
     def show(self):
         import IPython
         IPython.display.display(self._backend_objects['renderer'])
+
+    def _ipython_display_(self):
+        return self.show()

--- a/plato/draw/vispy/Scene.py
+++ b/plato/draw/vispy/Scene.py
@@ -180,3 +180,6 @@ class Scene(draw.Scene):
     def render(self):
         """Have vispy redraw this Scene object."""
         self._canvas.update()
+
+    def _ipython_display_(self):
+        return self.show()

--- a/plato/draw/zdog/Scene.py
+++ b/plato/draw/zdog/Scene.py
@@ -147,3 +147,6 @@ class Scene(draw.Scene):
 
         with open(filename, 'w') as f:
             f.write(result)
+
+    def _repr_html_(self):
+        return self.render()

--- a/plato/imp.py
+++ b/plato/imp.py
@@ -1,0 +1,166 @@
+"""
+The `imp` module defines an imperative API for convenient,
+immediate visualization of results without directly creating separate
+primitive and scene objects. The set of available primitives and
+attributes are the same as in :py:mod:`plato.draw`, but the functions
+in this module are named as lowercase_with_underscores rather than
+CamelCase class names. Final scenes can be shown either directly,
+allowing for more careful selection of backends and passing arguments
+to the underlying scene by using :py:func:`show` or automatically by
+using the `plato.imp` IPython extension.
+
+Examples::
+
+    import plato.imp as imp
+    imp.spheres(positions=[1, 0, 0])
+    imp.lines(start_points=(0, 1, 0), end_points=(1, 0, 0))
+    imp.show(backend='zdog', zoom=10)
+
+    # the line below causes cell contents to automatically be shown in jupyter notebooks
+    %load_ext plato.imp
+    imp.polygons(outline=.1)
+    imp.arrows_2D(positions=(-1, 0))
+
+"""
+import functools
+import importlib
+import plato.draw as draw
+import sys
+
+_pending_primitives = []
+_last_scene = None
+_used_vispy_backend = None
+
+_2d_primitives = (
+    draw.Arrows2D,
+    draw.Disks,
+    draw.DiskUnions,
+    draw.Polygons,
+    draw.Spheropolygons,
+    draw.Voronoi,
+)
+
+class _IPythonCallbacks(object):
+    def __init__(self, ip):
+        self.shell = ip
+
+    def post_run_cell(self, result):
+        if _pending_primitives:
+            show()
+
+def clear():
+    """Clears the imperative state."""
+    global _last_scene
+
+    _pending_primitives.clear()
+    _last_scene = None
+
+def _get_backend(backend, scene):
+    global _used_vispy_backend
+    if backend is None:
+        backend = _guess_backend(scene)
+
+    if backend.startswith('vispy_'):
+        if _used_vispy_backend is None:
+            vispy_backend = backend[len('vispy_'):]
+            import vispy, vispy.app
+            try:
+                vispy.app.use_app(vispy_backend)
+                _used_vispy_backend = vispy_backend
+            except RuntimeError:
+                _used_vispy_backend = vispy.app.use_app()
+        backend = 'vispy'
+
+    module_name = 'plato.draw.{}'.format(backend)
+    return importlib.import_module(module_name)
+
+def _get_scene(backend=None, **kwargs):
+    global _last_scene
+    pure_scene = draw.Scene(list(_pending_primitives), **kwargs)
+    backend = _get_backend(backend, pure_scene)
+    scene = _last_scene = pure_scene.convert(backend)
+
+    if any(isinstance(prim, _2d_primitives) for prim in _pending_primitives):
+        scene.enable('pan', True)
+    _pending_primitives.clear()
+
+    return scene
+
+def get(backend=None, **kwargs):
+    """Returns the last-shown imperative scene, or creates a new one.
+
+    This method returns the most recent scene, either that has been
+    shown via a call to `show()` or defined by calling
+    primitive-creating functions. If a new scene is created, the user
+    is responsible for calling `Scene.show()` as appropriate.
+    """
+    if _last_scene is None or _pending_primitives:
+        _get_scene(backend, **kwargs)
+    return _last_scene
+
+def _guess_backend(scene):
+    classes = [type(prim) for prim in scene]
+    backends = ['vispy', 'pythreejs', 'povray', 'fresnel', 'matplotlib', 'zdog']
+
+    for backend in backends:
+        try:
+            module_name = 'plato.draw.{}'.format(backend)
+            module = importlib.import_module(module_name)
+
+            # use the notebook backend by default
+            if backend == 'vispy' and 'ipykernel' in sys.modules:
+                backend = 'vispy_ipynb_webgl'
+
+            if all(hasattr(module, cls.__name__) for cls in classes):
+                return backend
+        except ImportError:
+            continue
+
+    msg = 'No backends were usable that support these classes: {}'.format(classes)
+    raise RuntimeError(msg)
+
+def load_ipython_extension(ip):
+    cb = _IPythonCallbacks(ip)
+    ip.events.register('post_run_cell', cb.post_run_cell)
+
+def _shape_dispatcher(cls, *args, **kwargs):
+    result = cls(*args, **kwargs)
+    _pending_primitives.append(result)
+    return result
+
+def _shape_generator(cls):
+    result = functools.partial(_shape_dispatcher, cls)
+    result = functools.update_wrapper(result, cls)
+
+    doc = result.__doc__ or ''
+    result.__doc__ = ('Generates and immediately displays the object described '
+                      'below.\n\n' + doc)
+
+    return result
+
+def show(backend=None, **kwargs):
+    """Immediately show all pending primitives that have been created.
+
+    A backend name can optionally be specified, but all other keyword
+    arguments are passed to the :py:class:`plato.draw.Scene`
+    constructor. If no backend is specified, a backend that can be
+    imported and supports all the pending primitives will be selected.
+    """
+    scene = _get_scene(backend, **kwargs)
+    scene.show()
+
+arrows2D = arrows_2D = _shape_generator(draw.Arrows2D)
+box = _shape_generator(draw.Box)
+convex_polyhedra = _shape_generator(draw.ConvexPolyhedra)
+convex_spheropolyhedra = _shape_generator(draw.ConvexSpheropolyhedra)
+disks = _shape_generator(draw.Disks)
+disk_unions = _shape_generator(draw.DiskUnions)
+ellipsoids = _shape_generator(draw.Ellipsoids)
+lines = _shape_generator(draw.Lines)
+mesh = _shape_generator(draw.Mesh)
+polygons = _shape_generator(draw.Polygons)
+sphere_points = _shape_generator(draw.SpherePoints)
+spheres = _shape_generator(draw.Spheres)
+sphere_unions = _shape_generator(draw.SphereUnions)
+spheropolygons = _shape_generator(draw.Spheropolygons)
+voronoi = _shape_generator(draw.Voronoi)

--- a/test/test_imp.py
+++ b/test/test_imp.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+import vispy, vispy.app
+vispy_backend_name = os.environ.get('VISPY_TEST_BACKEND', None)
+if vispy_backend_name:
+    vispy.app.use_app(vispy_backend_name)
+import plato.imp as imp
+
+class SceneTests(unittest.TestCase):
+    def tearDown(self):
+        imp.clear()
+
+    def test_basic(self):
+        imp.spheres()
+        imp.convex_polyhedra()
+
+        scene = imp.get()
+        self.assertEqual(len(scene), 2)
+
+        # calling get() without making new primitives returns the same scene...
+        scene = imp.get()
+        self.assertEqual(len(scene), 2)
+
+        # but adding a new primitive returns a new scene
+        imp.spheres()
+        scene = imp.get()
+        self.assertEqual(len(scene), 1)
+
+    def test_2d_pan(self):
+        imp.arrows_2D()
+        imp.disks()
+        imp.disk_unions()
+        imp.polygons()
+        imp.spheropolygons()
+        imp.voronoi()
+
+        scene = imp.get()
+        pan_enabled = scene.get_feature_config('pan')
+        self.assertIsNotNone(pan_enabled)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This proposed API makes quick visualizations more streamlined by automatically keeping track of primitive objects and displaying them. It can be used automatically (much like matplotlib figures get automatically displayed for each jupyter cell) in jupyter notebooks, or more manually controlled by `imp.show()`. I'm interested in hearing whether other users are interested in this API!