### PR TITLE
Quality-of-life improvements

### DIFF
--- a/plato/draw/Arrows2D.py
+++ b/plato/draw/Arrows2D.py
@@ -1,6 +1,7 @@
 import numpy as np
-from .Polygons import Polygons
+
 from .internal import ShapeDecorator
+from .Polygons import Polygons
 
 @ShapeDecorator
 class Arrows2D(Polygons):

--- a/plato/draw/Box.py
+++ b/plato/draw/Box.py
@@ -1,6 +1,8 @@
 import functools
 import itertools
+
 import numpy as np
+
 from .. import math
 from .internal import ShapeDecorator, ShapeAttribute
 from .Lines import Lines

--- a/plato/draw/ConvexPolyhedra.py
+++ b/plato/draw/ConvexPolyhedra.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/ConvexSpheropolyhedra.py
+++ b/plato/draw/ConvexSpheropolyhedra.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/DiskUnions.py
+++ b/plato/draw/DiskUnions.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Disks.py
+++ b/plato/draw/Disks.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Ellipsoids.py
+++ b/plato/draw/Ellipsoids.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Lines.py
+++ b/plato/draw/Lines.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Mesh.py
+++ b/plato/draw/Mesh.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 from .. import mesh
 

--- a/plato/draw/Polygons.py
+++ b/plato/draw/Polygons.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Scene.py
+++ b/plato/draw/Scene.py
@@ -28,6 +28,12 @@ class Scene:
       for prim in scene:
           # (do something with prim)
 
+    Primitives can also be accessed in the order they were added to
+    the scene using list-like syntax::
+
+      first_three_prims = scene[:3]
+      last_prim = scene[-1]
+
     Optional rendering arguments are enabled as *features*, which are
     name-value pairs identifying a feature by name and any
     configuration of the feature in the value.
@@ -82,6 +88,10 @@ class Scene:
 
         for name in kwargs:
             setattr(self, name, kwargs[name])
+
+    def __getitem__(self, key):
+        """Returns the primitive(s) given an integer index or slice."""
+        return self._primitives[key]
 
     def __iter__(self):
         for prim in self._primitives:

--- a/plato/draw/Scene.py
+++ b/plato/draw/Scene.py
@@ -1,5 +1,7 @@
 import logging
+
 import numpy as np
+
 from .internal import Shape
 
 DEFAULT_DIRECTIONAL_LIGHTS = (

--- a/plato/draw/SpherePoints.py
+++ b/plato/draw/SpherePoints.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/SphereUnions.py
+++ b/plato/draw/SphereUnions.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Spheres.py
+++ b/plato/draw/Spheres.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Spheropolygons.py
+++ b/plato/draw/Spheropolygons.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/Voronoi.py
+++ b/plato/draw/Voronoi.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import Shape, ShapeDecorator, ShapeAttribute
 
 @ShapeDecorator

--- a/plato/draw/__init__.py
+++ b/plato/draw/__init__.py
@@ -1,6 +1,5 @@
 from .Scene import Scene
 
-
 from .Arrows2D import Arrows2D
 from .Box import Box
 from .Disks import Disks

--- a/plato/draw/blender/ConvexPolyhedra.py
+++ b/plato/draw/blender/ConvexPolyhedra.py
@@ -1,7 +1,9 @@
-import bpy
 import itertools
-from ... import draw, geometry, math, mesh
+
+import bpy
 import numpy as np
+
+from ... import draw, geometry, math, mesh
 
 class ConvexPolyhedra(draw.ConvexPolyhedra):
 

--- a/plato/draw/blender/ConvexPolyhedra.py
+++ b/plato/draw/blender/ConvexPolyhedra.py
@@ -1,7 +1,6 @@
 import bpy
 import itertools
-from ... import geometry, math
-from ... import draw
+from ... import draw, geometry, math, mesh
 import numpy as np
 
 class ConvexPolyhedra(draw.ConvexPolyhedra):
@@ -22,8 +21,9 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
         group = bpy.data.groups.new(prim_name)
         positions = math.quatrot(rotation[np.newaxis, :], self.positions)
 
-        for (i, position, orientation, color) in zip(
-                itertools.count(), positions, self.orientations, self.colors):
+        particles = zip(*mesh.unfoldProperties([
+            positions, self.orientations, self.colors]))
+        for (i, (position, orientation, color)) in enumerate(particles):
             shape_name = prim_name + '_{}'.format(i)
             shape = bpy.data.objects.new(shape_name, object_data=mesh)
             shape.location = position

--- a/plato/draw/blender/Scene.py
+++ b/plato/draw/blender/Scene.py
@@ -1,6 +1,7 @@
-from ... import draw
-import numpy as np
 import bpy
+import numpy as np
+
+from ... import draw
 
 class Scene(draw.Scene):
     __doc__ = draw.Scene.__doc__

--- a/plato/draw/blender/Spheres.py
+++ b/plato/draw/blender/Spheres.py
@@ -1,7 +1,6 @@
 import bpy
 import itertools
-from ... import math
-from ... import draw
+from ... import draw, math, mesh
 import numpy as np
 
 class Spheres(draw.Spheres):
@@ -21,8 +20,9 @@ class Spheres(draw.Spheres):
         group = bpy.data.groups.new(prim_name)
         positions = math.quatrot(rotation[np.newaxis, :], self.positions)
 
-        for (i, position, radius, color) in zip(
-                itertools.count(), positions, self.radii, self.colors):
+        particles = zip(*mesh.unfoldProperties([
+            positions, self.radii, self.colors]))
+        for (i, (position, (radius,), color)) in enumerate(particles):
             shape_name = prim_name + '_{}'.format(i)
             shape = bpy.data.objects.new(shape_name, object_data=shape_params)
             shape.location = position

--- a/plato/draw/blender/Spheres.py
+++ b/plato/draw/blender/Spheres.py
@@ -1,7 +1,9 @@
-import bpy
 import itertools
-from ... import draw, math, mesh
+
+import bpy
 import numpy as np
+
+from ... import draw, math, mesh
 
 class Spheres(draw.Spheres):
 

--- a/plato/draw/fresnel/ConvexPolyhedra.py
+++ b/plato/draw/fresnel/ConvexPolyhedra.py
@@ -1,6 +1,8 @@
-import fresnel
 import itertools
+
+import fresnel
 import numpy as np
+
 from ... import draw
 from ..internal import ShapeAttribute, ShapeDecorator
 from .FresnelPrimitive import FresnelPrimitive

--- a/plato/draw/fresnel/Disks.py
+++ b/plato/draw/fresnel/Disks.py
@@ -1,4 +1,5 @@
 import fresnel
+
 from ... import draw
 from .FresnelPrimitive import FresnelPrimitiveSolid
 

--- a/plato/draw/fresnel/Ellipsoids.py
+++ b/plato/draw/fresnel/Ellipsoids.py
@@ -1,6 +1,8 @@
-import fresnel
 import itertools
+
+import fresnel
 import numpy as np
+
 from ... import draw
 from ...geometry import fibonacciPositions
 from ..internal import ShapeAttribute, ShapeDecorator

--- a/plato/draw/fresnel/Lines.py
+++ b/plato/draw/fresnel/Lines.py
@@ -1,6 +1,8 @@
-import fresnel
 import itertools
+
+import fresnel
 import numpy as np
+
 from ... import draw
 from ..internal import ShapeAttribute, ShapeDecorator
 from .FresnelPrimitive import FresnelPrimitiveSolid

--- a/plato/draw/fresnel/Polygons.py
+++ b/plato/draw/fresnel/Polygons.py
@@ -1,7 +1,8 @@
 import fresnel
+import rowan
+
 from ... import draw
 from .FresnelPrimitive import FresnelPrimitiveSolid
-import rowan
 
 class Polygons(FresnelPrimitiveSolid, draw.Polygons):
     __doc__ = draw.Polygons.__doc__

--- a/plato/draw/fresnel/Scene.py
+++ b/plato/draw/fresnel/Scene.py
@@ -31,7 +31,7 @@ class Scene(draw.Scene):
         import IPython
         if self._output is None:
             self.render()
-        IPython.display.display(self._output)
+        IPython.display.display(self._output, display_id=str(id(self)))
 
     def save(self, filename):
         """Render and save an image of this Scene.

--- a/plato/draw/fresnel/Scene.py
+++ b/plato/draw/fresnel/Scene.py
@@ -1,8 +1,8 @@
 import fresnel
 import numpy as np
 import rowan
-from ... import draw
 
+from ... import draw
 
 class Scene(draw.Scene):
     __doc__ = (draw.Scene.__doc__ or '') + """

--- a/plato/draw/fresnel/SphereUnions.py
+++ b/plato/draw/fresnel/SphereUnions.py
@@ -1,8 +1,9 @@
 import fresnel
+import numpy as np
+
 from ... import draw
 from ... import math
 from .FresnelPrimitive import FresnelPrimitive
-import numpy as np
 
 class SphereUnions(FresnelPrimitive, draw.SphereUnions):
     __doc__ = draw.SphereUnions.__doc__

--- a/plato/draw/fresnel/Spheres.py
+++ b/plato/draw/fresnel/Spheres.py
@@ -1,4 +1,5 @@
 import fresnel
+
 from ... import draw
 from .FresnelPrimitive import FresnelPrimitive
 

--- a/plato/draw/fresnel/Spheropolygons.py
+++ b/plato/draw/fresnel/Spheropolygons.py
@@ -1,7 +1,8 @@
 import fresnel
+import rowan
+
 from ... import draw
 from .FresnelPrimitive import FresnelPrimitiveSolid
-import rowan
 
 class Spheropolygons(FresnelPrimitiveSolid, draw.Spheropolygons):
     __doc__ = draw.Spheropolygons.__doc__

--- a/plato/draw/internal.py
+++ b/plato/draw/internal.py
@@ -1,6 +1,7 @@
+from collections import namedtuple
 import functools
 import inspect
-from collections import namedtuple
+
 import numpy as np
 
 ATTRIBUTE_DOCSTRING_HEADER = '\n\nThis primitive has the following attributes:'

--- a/plato/draw/matplotlib/ConvexPolyhedra.py
+++ b/plato/draw/matplotlib/ConvexPolyhedra.py
@@ -1,10 +1,11 @@
 import numpy as np
+from matplotlib.path import Path
+from matplotlib.patches import PathPatch, Polygon
+
 from ... import math
 from ... import geometry
 from ... import draw
 from .internal import PatchUser
-from matplotlib.path import Path
-from matplotlib.patches import PathPatch, Polygon
 
 class ConvexPolyhedra(draw.ConvexPolyhedra, PatchUser):
     __doc__ = draw.ConvexPolyhedra.__doc__

--- a/plato/draw/matplotlib/DiskUnions.py
+++ b/plato/draw/matplotlib/DiskUnions.py
@@ -1,8 +1,9 @@
-import numpy as np
-from ... import draw
-from .internal import PatchUser
 from matplotlib.patches import Circle, Wedge
 from matplotlib.transforms import Affine2D
+import numpy as np
+
+from ... import draw
+from .internal import PatchUser
 
 class DiskUnions(draw.DiskUnions, PatchUser):
     __doc__ = draw.DiskUnions.__doc__

--- a/plato/draw/matplotlib/Disks.py
+++ b/plato/draw/matplotlib/Disks.py
@@ -1,7 +1,8 @@
+from matplotlib.patches import Circle, Wedge
 import numpy as np
+
 from ... import draw
 from .internal import PatchUser
-from matplotlib.patches import Circle, Wedge
 
 class Disks(draw.Disks, PatchUser):
     __doc__ = draw.Disks.__doc__

--- a/plato/draw/matplotlib/Polygons.py
+++ b/plato/draw/matplotlib/Polygons.py
@@ -1,10 +1,11 @@
-import numpy as np
-from ... import geometry
-from ... import draw
-from .internal import PatchUser
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch, Polygon
 from matplotlib.transforms import Affine2D
+import numpy as np
+
+from ... import geometry
+from ... import draw
+from .internal import PatchUser
 
 class Polygons(draw.Polygons, PatchUser):
     __doc__ = draw.Polygons.__doc__

--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -1,7 +1,17 @@
+import contextlib
 import matplotlib.pyplot as pp
 from matplotlib.collections import PatchCollection
-from ... import draw
 import numpy as np
+from ... import draw
+
+@contextlib.contextmanager
+def manage_matplotlib_interactive():
+    was_interactive = pp.isinteractive()
+    pp.ioff()
+
+    yield None
+    if was_interactive:
+        pp.ion()
 
 class Scene(draw.Scene):
     __doc__ = (draw.Scene.__doc__ or '') + """
@@ -97,4 +107,7 @@ class Scene(draw.Scene):
         return figure.savefig(filename, dpi=figure.dpi)
 
     def _ipython_display_(self):
-        return self.show()
+        import IPython.display
+        with manage_matplotlib_interactive():
+            (fig, _) = self.render()
+        return IPython.display.display(fig, display_id=str(id(self)))

--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -1,7 +1,9 @@
 import contextlib
+
 import matplotlib.pyplot as pp
 from matplotlib.collections import PatchCollection
 import numpy as np
+
 from ... import draw
 
 @contextlib.contextmanager

--- a/plato/draw/matplotlib/SpherePoints.py
+++ b/plato/draw/matplotlib/SpherePoints.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ... import draw
 from ... import math
 

--- a/plato/draw/matplotlib/Spheres.py
+++ b/plato/draw/matplotlib/Spheres.py
@@ -1,10 +1,12 @@
 import itertools
+
+from matplotlib.patches import Circle
 import numpy as np
+
 from ... import math
 from ... import draw
 from ...draw import internal
 from .internal import PatchUser
-from matplotlib.patches import Circle
 
 @internal.ShapeDecorator
 class Spheres(draw.Spheres, PatchUser):

--- a/plato/draw/matplotlib/Spheropolygons.py
+++ b/plato/draw/matplotlib/Spheropolygons.py
@@ -1,9 +1,10 @@
-import numpy as np
-from ... import draw
-from .internal import PatchUser
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
+import numpy as np
+
+from ... import draw
+from .internal import PatchUser
 
 class Spheropolygons(draw.Spheropolygons, PatchUser):
     __doc__ = draw.Spheropolygons.__doc__

--- a/plato/draw/povray/ConvexPolyhedra.py
+++ b/plato/draw/povray/ConvexPolyhedra.py
@@ -18,7 +18,9 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
 
     def render(self, rotation=(1, 0, 0, 0), name_suffix='', **kwargs):
         rotation = np.asarray(rotation)
-        quat_magnitude = np.linalg.norm(self.orientations, axis=-1, keepdims=True)
+        (positions, orientations, colors) = pmesh.unfoldProperties([
+            self.positions, self.orientations, self.colors])
+        quat_magnitude = np.linalg.norm(orientations, axis=-1, keepdims=True)
 
         lines = []
 
@@ -39,7 +41,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
             lines.append(shapedef)
 
             qs = pmath.quatquat(rotation[np.newaxis, :],
-                                self.orientations/quat_magnitude)
+                                orientations/quat_magnitude)
             rotmat = np.array([[1 - 2*qs[:, 2]**2 - 2*qs[:, 3]**2,
                                 2*(qs[:, 1]*qs[:, 2] - qs[:, 3]*qs[:, 0]),
                                 2*(qs[:, 1]*qs[:, 3] + qs[:, 2]*qs[:, 0])],
@@ -52,9 +54,9 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
             rotmat = rotmat.transpose([2, 1, 0]).reshape((-1, 9))
             rotmat[:] *= quat_magnitude[:, 0, np.newaxis]**2
 
-            positions = pmath.quatrot(rotation[np.newaxis, :], self.positions)
+            positions = pmath.quatrot(rotation[np.newaxis, :], positions)
 
-            for (p, m, a) in zip(positions, rotmat, 1 - self.colors[:, 3]):
+            for (p, m, a) in zip(positions, rotmat, 1 - colors[:, 3]):
                 args = [shapeName] + m.tolist() + p.tolist() + [0, 0, 0, a]
                 lines.append('object {{{} matrix <{},{},{},{},{},{},{},{},{},'
                              '{},{},{}> pigment {{color <{},{},{}> transmit {} }}}}'.format(
@@ -71,7 +73,7 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
         shapedef = '#declare {} = {}'.format(shapeName, meshStr)
         lines.append(shapedef)
 
-        qs = pmath.quatquat(rotation[np.newaxis, :], self.orientations/quat_magnitude)
+        qs = pmath.quatquat(rotation[np.newaxis, :], orientations/quat_magnitude)
         rotmat = np.array([[1 - 2*qs[:, 2]**2 - 2*qs[:, 3]**2,
                             2*(qs[:, 1]*qs[:, 2] - qs[:, 3]*qs[:, 0]),
                             2*(qs[:, 1]*qs[:, 3] + qs[:, 2]*qs[:, 0])],
@@ -84,10 +86,10 @@ class ConvexPolyhedra(draw.ConvexPolyhedra):
         rotmat = rotmat.transpose([2, 1, 0]).reshape((-1, 9))
         rotmat *= quat_magnitude[:, 0, np.newaxis]**2
 
-        positions = pmath.quatrot(rotation[np.newaxis, :], self.positions)
+        positions = pmath.quatrot(rotation[np.newaxis, :], positions)
 
-        for (p, m, (r, g, b), a) in zip(positions, rotmat, self.colors[:, :3],
-                                        1 - self.colors[:, 3]):
+        for (p, m, (r, g, b), a) in zip(positions, rotmat, colors[:, :3],
+                                        1 - colors[:, 3]):
             args = [shapeName] + m.tolist() + p.tolist() + [r, g, b, a]
             lines.append('object {{{} matrix <{},{},{},{},{},{},{},{},{},'
                          '{},{},{}> pigment {{color <{},{},{}> transmit '

--- a/plato/draw/povray/ConvexPolyhedra.py
+++ b/plato/draw/povray/ConvexPolyhedra.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import draw
 from ... import mesh as pmesh
 from ... import geometry

--- a/plato/draw/povray/ConvexSpheropolyhedra.py
+++ b/plato/draw/povray/ConvexSpheropolyhedra.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ... import draw
 from ... import mesh as pmesh
 from ... import geometry

--- a/plato/draw/povray/ConvexSpheropolyhedra.py
+++ b/plato/draw/povray/ConvexSpheropolyhedra.py
@@ -9,7 +9,9 @@ class ConvexSpheropolyhedra(draw.ConvexSpheropolyhedra):
 
     def render(self, rotation=(1, 0, 0, 0), name_suffix='', **kwargs):
         rotation = np.asarray(rotation)
-        quat_magnitude = np.linalg.norm(self.orientations, axis=-1, keepdims=True)
+        (positions, orientations, colors) = pmesh.unfoldProperties([
+            self.positions, self.orientations, self.colors])
+        quat_magnitude = np.linalg.norm(orientations, axis=-1, keepdims=True)
 
         lines = []
         decomp = geometry.convexDecomposition(self.vertices)
@@ -32,7 +34,7 @@ class ConvexSpheropolyhedra(draw.ConvexSpheropolyhedra):
             shapeName, '\n'.join(elt for elt in [meshStr] + edges + spheres))
         lines.append(shapedef)
 
-        qs = pmath.quatquat(rotation[np.newaxis, :], self.orientations/quat_magnitude)
+        qs = pmath.quatquat(rotation[np.newaxis, :], orientations/quat_magnitude)
         rotmat = np.array([[1 - 2*qs[:, 2]**2 - 2*qs[:, 3]**2,
                             2*(qs[:, 1]*qs[:, 2] - qs[:, 3]*qs[:, 0]),
                             2*(qs[:, 1]*qs[:, 3] + qs[:, 2]*qs[:, 0])],
@@ -45,9 +47,9 @@ class ConvexSpheropolyhedra(draw.ConvexSpheropolyhedra):
         rotmat = rotmat.transpose([2, 1, 0]).reshape((-1, 9))
         rotmat[:] *= quat_magnitude[:, 0, np.newaxis]**2
 
-        positions = pmath.quatrot(rotation[np.newaxis, :], self.positions)
+        positions = pmath.quatrot(rotation[np.newaxis, :], positions)
 
-        for (p, m, c) in zip(positions, rotmat, self.colors[:, :3]):
+        for (p, m, c) in zip(positions, rotmat, colors[:, :3]):
             args = [shapeName] + m.tolist() + p.tolist() + c.tolist()
             lines.append('object {{{} matrix <{},{},{},{},{},{},{},{},{},'
                          '{},{},{}> pigment {{color <{},{},{}>}}}}'.format(

--- a/plato/draw/povray/Ellipsoids.py
+++ b/plato/draw/povray/Ellipsoids.py
@@ -1,19 +1,21 @@
 import numpy as np
 import rowan
-from ... import draw
+from ... import draw, mesh
 
 class Ellipsoids(draw.Ellipsoids):
     __doc__ = draw.Ellipsoids.__doc__
 
     def render(self, rotation=(1, 0, 0, 0), **kwargs):
-        positions = rowan.rotate(rotation, self.positions)
+        (positions, orientations, colors) = mesh.unfoldProperties([
+            self.positions, self.orientations, self.colors])
+        positions = rowan.rotate(rotation, positions)
         orientations = rowan.multiply(
-            rotation, rowan.normalize(self.orientations))
+            rotation, rowan.normalize(orientations))
         rotations = np.degrees(rowan.to_euler(orientations))
 
         lines = []
         for (pos, rot, col, alpha) in zip(
-                positions, rotations, self.colors[:, :3], 1 - self.colors[:, 3]):
+                positions, rotations, colors[:, :3], 1 - colors[:, 3]):
             lines.append('sphere {{ '
                          '0, 1 scale<{a}, {b}, {c}> '
                          'rotate <{rot[2]}, {rot[1]}, {rot[0]}> '

--- a/plato/draw/povray/Ellipsoids.py
+++ b/plato/draw/povray/Ellipsoids.py
@@ -1,5 +1,6 @@
 import numpy as np
 import rowan
+
 from ... import draw, mesh
 
 class Ellipsoids(draw.Ellipsoids):

--- a/plato/draw/povray/Lines.py
+++ b/plato/draw/povray/Lines.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import draw
 from ..internal import ShapeDecorator, ShapeAttribute
 from ... import math as pmath

--- a/plato/draw/povray/Mesh.py
+++ b/plato/draw/povray/Mesh.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ... import draw
 from ... import math as pmath
 from ... import mesh

--- a/plato/draw/povray/Mesh.py
+++ b/plato/draw/povray/Mesh.py
@@ -15,8 +15,8 @@ class Mesh(draw.Mesh):
             vertex_colors = np.tile(
                 vertex_colors, (int(np.ceil(len(verts)/len(vertex_colors))), 1))
 
-        positions = self.positions
-        shape_colors = self.shape_colors
+        (positions, orientations, shape_colors) = mesh.unfoldProperties([
+            self.positions, self.orientations, self.shape_colors])
         if len(shape_colors) < len(positions):
             shape_colors = np.tile(
                 shape_colors, (int(np.ceil(len(positions)/len(shape_colors))), 1))
@@ -31,8 +31,8 @@ class Mesh(draw.Mesh):
         vertex_normals = mesh.computeNormals_(verts, self.indices)
         vertex_normal_text = ' '.join('<{},{},{}>'.format(*v) for v in vertex_normals)
 
-        quat_magnitude = np.linalg.norm(self.orientations, axis=-1, keepdims=True)
-        qs = pmath.quatquat(rotation[np.newaxis, :], self.orientations/quat_magnitude)
+        quat_magnitude = np.linalg.norm(orientations, axis=-1, keepdims=True)
+        qs = pmath.quatquat(rotation[np.newaxis, :], orientations/quat_magnitude)
         rotmats = np.array([[1 - 2*qs[:, 2]**2 - 2*qs[:, 3]**2,
                             2*(qs[:, 1]*qs[:, 2] - qs[:, 3]*qs[:, 0]),
                             2*(qs[:, 1]*qs[:, 3] + qs[:, 2]*qs[:, 0])],

--- a/plato/draw/povray/Scene.py
+++ b/plato/draw/povray/Scene.py
@@ -128,7 +128,8 @@ class Scene(draw.Scene):
 
         with tempfile.NamedTemporaryFile(suffix='.png') as temp:
             self.save(temp.name)
-            return IPython.display.Image(filename=temp.name)
+            img = IPython.display.Image(filename=temp.name)
+            return IPython.display.display(img, display_id=str(id(self)))
 
     def save(self, filename):
         """Save the scene, either as povray source or a rendered image.

--- a/plato/draw/povray/Scene.py
+++ b/plato/draw/povray/Scene.py
@@ -3,10 +3,11 @@ import os
 import subprocess
 import tempfile
 
+import numpy as np
+
 from ... import draw
 from ... import math
 from ... import __version__
-import numpy as np
 
 class Scene(draw.Scene):
     __doc__ = (draw.Scene.__doc__ or '') + """

--- a/plato/draw/povray/SphereUnions.py
+++ b/plato/draw/povray/SphereUnions.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ... import draw
 from ... import math
 from ... import mesh

--- a/plato/draw/povray/SphereUnions.py
+++ b/plato/draw/povray/SphereUnions.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ... import draw
 from ... import math
+from ... import mesh
 
 class SphereUnions(draw.SphereUnions):
     __doc__ = draw.SphereUnions.__doc__
@@ -8,11 +9,14 @@ class SphereUnions(draw.SphereUnions):
     def render(self, rotation=(1, 0, 0, 0), **kwargs):
         rotation = np.asarray(rotation)
 
-        positions = np.tile(self.positions[:, np.newaxis, :], (1, len(self.points), 1))
-        positions += math.quatrot(self.orientations[:, np.newaxis], self.points[np.newaxis])
+        (positions, orientations) = mesh.unfoldProperties([
+            self.positions, self.orientations])
 
-        radii = np.repeat(self.radii[np.newaxis, :], len(self.positions),axis=0)
-        colors = np.repeat(self.colors[np.newaxis, :], len(self.positions), axis=0)
+        positions = np.tile(positions[:, np.newaxis, :], (1, len(self.points), 1))
+        positions += math.quatrot(orientations[:, np.newaxis], self.points[np.newaxis])
+
+        radii = np.repeat(self.radii[np.newaxis, :], len(positions),axis=0)
+        colors = np.repeat(self.colors[np.newaxis, :], len(positions), axis=0)
 
         colors_reshaped = colors.reshape(-1,4)
 

--- a/plato/draw/povray/Spheres.py
+++ b/plato/draw/povray/Spheres.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ... import draw
 from ... import math
 from ... import mesh

--- a/plato/draw/povray/Spheres.py
+++ b/plato/draw/povray/Spheres.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ... import draw
 from ... import math
+from ... import mesh
 
 class Spheres(draw.Spheres):
     __doc__ = draw.Spheres.__doc__
@@ -8,11 +9,13 @@ class Spheres(draw.Spheres):
     def render(self, rotation=(1, 0, 0, 0), **kwargs):
         rotation = np.asarray(rotation)
 
-        positions = math.quatrot(rotation[np.newaxis, :], self.positions)
+        (positions, radii, colors) = mesh.unfoldProperties([
+            self.positions, self.radii, self.colors])
+        positions = math.quatrot(rotation[np.newaxis, :], positions)
 
         lines = []
-        for (p, r, c, a) in zip(positions, self.radii, self.colors[:, :3],
-                                1 - self.colors[:, 3]):
+        for (p, r, c, a) in zip(positions, radii[:, 0], colors[:, :3],
+                                1 - colors[:, 3]):
             args = p.tolist() + [r] + c.tolist() + [a]
             lines.append('sphere {{<{},{},{}> {} pigment {{color '
                          '<{},{},{}> transmit {}}}}}'.format(*args))

--- a/plato/draw/pythreejs/ConvexPolyhedra.py
+++ b/plato/draw/pythreejs/ConvexPolyhedra.py
@@ -1,7 +1,8 @@
+import numpy as np
+
 from ... import draw
 from ... import mesh
 from .internal import ThreeJSPrimitive
-import numpy as np
 
 class ConvexPolyhedra(draw.ConvexPolyhedra, ThreeJSPrimitive):
     __doc__ = draw.ConvexPolyhedra.__doc__

--- a/plato/draw/pythreejs/ConvexSpheropolyhedra.py
+++ b/plato/draw/pythreejs/ConvexSpheropolyhedra.py
@@ -1,7 +1,8 @@
+import numpy as np
+
 from ... import draw
 from ... import mesh
 from .internal import ThreeJSPrimitive
-import numpy as np
 
 class ConvexSpheropolyhedra(draw.ConvexSpheropolyhedra, ThreeJSPrimitive):
     __doc__ = draw.ConvexSpheropolyhedra.__doc__

--- a/plato/draw/pythreejs/Ellipsoids.py
+++ b/plato/draw/pythreejs/Ellipsoids.py
@@ -1,10 +1,12 @@
 import itertools
+
+import numpy as np
+
 from ... import draw
 from ...geometry import fibonacciPositions
 from ... import mesh
 from .internal import ThreeJSPrimitive
 from ..internal import ShapeAttribute, ShapeDecorator
-import numpy as np
 
 @ShapeDecorator
 class Ellipsoids(draw.Ellipsoids, ThreeJSPrimitive):

--- a/plato/draw/pythreejs/Lines.py
+++ b/plato/draw/pythreejs/Lines.py
@@ -1,8 +1,9 @@
+import numpy as np
+import rowan
+
 from ... import draw
 from ... import geometry
 from .internal import ThreeJSPrimitive
-import numpy as np
-import rowan
 
 class Lines(draw.Lines, ThreeJSPrimitive):
     __doc__ = draw.Lines.__doc__

--- a/plato/draw/pythreejs/Mesh.py
+++ b/plato/draw/pythreejs/Mesh.py
@@ -1,7 +1,8 @@
+import numpy as np
+
 from ... import draw
 from ... import mesh
 from .internal import ThreeJSPrimitive
-import numpy as np
 
 class Mesh(draw.Mesh, ThreeJSPrimitive):
     __doc__ = draw.Mesh.__doc__

--- a/plato/draw/pythreejs/Scene.py
+++ b/plato/draw/pythreejs/Scene.py
@@ -1,8 +1,9 @@
-from ... import draw
-from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 import rowan
 import numpy as np
 import pythreejs
+
+from ... import draw
+from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 
 class Scene(draw.Scene):
     def __init__(self, *args, **kwargs):

--- a/plato/draw/pythreejs/Scene.py
+++ b/plato/draw/pythreejs/Scene.py
@@ -179,8 +179,9 @@ class Scene(draw.Scene):
                 self._backend_objects['camera'].add(light)
 
     def show(self):
-        import IPython
-        IPython.display.display(self._backend_objects['renderer'])
+        import IPython.display
+        IPython.display.display(
+            self._backend_objects['renderer'], display_id=str(id(self)))
 
     def _ipython_display_(self):
         return self.show()

--- a/plato/draw/pythreejs/Spheres.py
+++ b/plato/draw/pythreejs/Spheres.py
@@ -1,10 +1,12 @@
 import itertools
+
+import numpy as np
+
 from ... import draw
 from ...geometry import fibonacciPositions
 from ... import mesh
 from .internal import ThreeJSPrimitive
 from ..internal import ShapeAttribute, ShapeDecorator
-import numpy as np
 
 @ShapeDecorator
 class Spheres(draw.Spheres, ThreeJSPrimitive):

--- a/plato/draw/pythreejs/internal.py
+++ b/plato/draw/pythreejs/internal.py
@@ -1,6 +1,7 @@
-from ... import math
 import numpy as np
 import pythreejs
+
+from ... import math
 
 class ThreeJSPrimitive:
     @property

--- a/plato/draw/vispy/ConvexPolyhedra.py
+++ b/plato/draw/vispy/ConvexPolyhedra.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/ConvexSpheropolyhedra.py
+++ b/plato/draw/vispy/ConvexSpheropolyhedra.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/DiskUnions.py
+++ b/plato/draw/vispy/DiskUnions.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Disks.py
+++ b/plato/draw/vispy/Disks.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Ellipsoids.py
+++ b/plato/draw/vispy/Ellipsoids.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from .Spheres import Spheres

--- a/plato/draw/vispy/Lines.py
+++ b/plato/draw/vispy/Lines.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Mesh.py
+++ b/plato/draw/vispy/Mesh.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Polygons.py
+++ b/plato/draw/vispy/Polygons.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import geometry
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator

--- a/plato/draw/vispy/Scene.py
+++ b/plato/draw/vispy/Scene.py
@@ -1,8 +1,10 @@
 import logging
+
+import numpy as np
 import vispy.io
+
 from .Canvas import Canvas
 from ... import draw
-import numpy as np
 from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS
 
 logger = logging.getLogger(__name__)

--- a/plato/draw/vispy/Scene.py
+++ b/plato/draw/vispy/Scene.py
@@ -167,7 +167,8 @@ class Scene(draw.Scene):
                 target = io.BytesIO()
                 img = self._canvas.render()
                 imageio.imwrite(target, img, 'png')
-                return IPython.display.Image(data=target.getvalue())
+                to_display = IPython.display.Image(data=target.getvalue())
+                return IPython.display.display(to_display, display_id=str(id(self)))
 
             msg = ('vispy has already loaded the {} backend, ignoring static'
                    ' feature. Try manually selecting a desktop vispy backend '

--- a/plato/draw/vispy/SpherePoints.py
+++ b/plato/draw/vispy/SpherePoints.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw
 from ..internal import ShapeAttribute

--- a/plato/draw/vispy/SphereUnions.py
+++ b/plato/draw/vispy/SphereUnions.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Spheres.py
+++ b/plato/draw/vispy/Spheres.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Spheropolygons.py
+++ b/plato/draw/vispy/Spheropolygons.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/Voronoi.py
+++ b/plato/draw/vispy/Voronoi.py
@@ -1,5 +1,7 @@
 import itertools
+
 import numpy as np
+
 from ... import mesh
 from .internal import GLPrimitive, GLShapeDecorator
 from ... import draw

--- a/plato/draw/vispy/internal.py
+++ b/plato/draw/vispy/internal.py
@@ -1,8 +1,10 @@
 import functools
 import itertools
+
 import numpy as np
 import vispy, vispy.app
 from vispy import gloo
+
 from ... import mesh
 from ..internal import array_size_checkers, ATTRIBUTE_DOCSTRING_TEMPLATE
 from ..Scene import DEFAULT_DIRECTIONAL_LIGHTS

--- a/plato/draw/zdog/Lines.py
+++ b/plato/draw/zdog/Lines.py
@@ -1,4 +1,5 @@
 from ... import draw
+from ... import mesh
 
 class Lines(draw.Lines):
     __doc__ = draw.Lines.__doc__
@@ -9,10 +10,10 @@ class Lines(draw.Lines):
         # and z is toward you
         lines = []
 
-        particles = zip(
+        particles = zip(*mesh.unfoldProperties([
             self.start_points*(1, -1, 1), self.end_points*(1, -1, 1),
-            self.widths, self.colors*255)
-        for i, (start, end, width, color) in enumerate(particles):
+            self.widths, self.colors*255]))
+        for i, (start, end, (width,), color) in enumerate(particles):
             path = ', '.join('{{x: {}, y: {}, z: {}}}'.format(*v) for v in [start, end])
 
             (r, g, b) = map(int, color[:3])

--- a/plato/draw/zdog/Scene.py
+++ b/plato/draw/zdog/Scene.py
@@ -1,6 +1,7 @@
-from ... import draw
 import numpy as np
 import rowan
+
+from ... import draw
 
 LOCAL_HELPER_SCRIPT = """
 let is_in_view = function(elt) {

--- a/plato/draw/zdog/Scene.py
+++ b/plato/draw/zdog/Scene.py
@@ -136,10 +136,11 @@ class Scene(draw.Scene):
     def show(self):
         """Render the scene to an image and display using ipython."""
         import IPython.display
-        return IPython.display.HTML(self.render())
+        disp = IPython.display.HTML(self.render())
+        return IPython.display.display(disp, display_id=str(id(self)))
 
     def save(self, filename):
-        """Save the scene, either as povray source or a rendered image.
+        """Save the scene as an HTML file.
 
         :param filename: target filename to save the result into
         """

--- a/plato/draw/zdog/Spheres.py
+++ b/plato/draw/zdog/Spheres.py
@@ -1,6 +1,8 @@
 import collections
 import itertools
+
 import numpy as np
+
 from ... import draw, mesh
 from ...draw import internal
 

--- a/plato/draw/zdog/Spheres.py
+++ b/plato/draw/zdog/Spheres.py
@@ -1,7 +1,7 @@
 import collections
 import itertools
 import numpy as np
-from ... import draw
+from ... import draw, mesh
 from ...draw import internal
 
 LightInfo = collections.namedtuple(
@@ -34,9 +34,9 @@ class Spheres(draw.Spheres):
 
             light_info.append(LightInfo(normal, mag))
 
-        particles = zip(
-            self.positions*(1, -1, 1), self.diameters, self.colors*255)
-        for i, (position, diameter, color) in enumerate(particles):
+        particles = zip(*mesh.unfoldProperties([
+            self.positions*(1, -1, 1), self.diameters, self.colors*255]))
+        for i, (position, (diameter,), color) in enumerate(particles):
             group_index = 'sphere_{}_{}'.format(name_suffix, i)
 
             lines.append("""

--- a/plato/draw/zdog/internal.py
+++ b/plato/draw/zdog/internal.py
@@ -1,6 +1,6 @@
 import numpy as np
 import rowan
-from ... import geometry
+from ... import geometry, mesh
 
 class PolyhedronRenderer:
     def render(self, rotation=(1, 0, 0, 0), name_suffix='', illo_id='illo',
@@ -31,9 +31,9 @@ class PolyhedronRenderer:
         orientations_euler = rowan.to_euler(
             self.orientations, convention='xyz', axis_type='intrinsic')
 
-        particles = zip(
+        particles = zip(*mesh.unfoldProperties([
             self.positions*(1, -1, 1), self.orientations,
-            -orientations_euler, self.colors*255)
+            -orientations_euler, self.colors*255]))
         for i, (position, orientation, eulers, color) in enumerate(particles):
             group_index = 'convexPoly_{}_{}'.format(name_suffix, i)
 

--- a/plato/draw/zdog/internal.py
+++ b/plato/draw/zdog/internal.py
@@ -1,5 +1,6 @@
 import numpy as np
 import rowan
+
 from ... import geometry, mesh
 
 class PolyhedronRenderer:

--- a/plato/imp.py
+++ b/plato/imp.py
@@ -24,8 +24,9 @@ Examples::
 """
 import functools
 import importlib
-import plato.draw as draw
 import sys
+
+from . import draw
 
 _pending_primitives = []
 _last_scene = None

--- a/plato/mesh.py
+++ b/plato/mesh.py
@@ -1,6 +1,7 @@
 
 from collections import defaultdict, namedtuple
 from itertools import repeat
+
 import numpy as np
 
 from .geometry import convexHull, insetPolygon, massProperties, Polygon

--- a/test/test_Scene.py
+++ b/test/test_Scene.py
@@ -83,5 +83,19 @@ class SceneTests(unittest.TestCase):
             scene.get_feature_config('test3'),
             {'value': 'auto_value', 'another_value': None})
 
+    def test_indexing(self):
+        prim0 = draw.Spheres()
+        prim1 = draw.ConvexPolyhedra()
+
+        scene = draw.Scene([prim0, prim1])
+
+        self.assertIs(scene[0], prim0)
+        self.assertIs(scene[-1], prim1)
+        self.assertEqual(scene[:2], [prim0, prim1])
+        self.assertEqual(scene[:3], [prim0, prim1])
+
+        with self.assertRaises(IndexError):
+            scene[5]
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR improves the treatment of a few relatively minor issues.

1. Use `display_id` for `IPython.display.display` calls in `Scene.show()` for many backends. This causes IPython to automatically clear the location where the scene was previously displayed.
2. Automatically broadcast quantities that have a size of 1 in `mesh.unfoldProperties`. This should fix most of the confusion cases when only one particle gets drawn (see #11), although it isn't the most elegant solution.
3. Add ability to index `Scene` objects by integers or slices to get primitives. Part of #49.