### PR TITLE
Add official selection API to vispy Scenes

### DIFF
--- a/plato/draw/Scene.py
+++ b/plato/draw/Scene.py
@@ -86,7 +86,7 @@ class Scene:
 
                 self.enable(feature, **config)
             else:
-                self.enable(feature, value=config)
+                self.enable(feature, auto_value=config)
 
         for name in kwargs:
             setattr(self, name, kwargs[name])

--- a/plato/draw/vispy/Canvas.py
+++ b/plato/draw/vispy/Canvas.py
@@ -451,7 +451,7 @@ class Canvas(vispy.app.Canvas):
         self._final_render_target = NoopContextManager()
         self._scene = scene
         self._mouse_origin = np.array([0, 0], dtype=np.float32)
-        self._selection_callback = None
+        self._selection_callbacks = []
         self._clip_planes = np.array([1, 100], dtype=np.float32)
 
         super(Canvas, self).__init__(size=scene.size_pixels.astype(np.uint32), **kwargs)
@@ -614,9 +614,8 @@ class Canvas(vispy.app.Canvas):
         self._mouse_origin[:] = event.pos
 
     def on_mouse_release(self, event):
-        if self._selection_callback is not None:
-            callback = self._selection_callback
-            self._selection_callback = None
+        if self._selection_callbacks:
+            callback = self._selection_callbacks.pop()
             callback(self._mouse_origin, event.pos)
 
     def _mouse_translate(self, delta):
@@ -631,7 +630,7 @@ class Canvas(vispy.app.Canvas):
         self.update()
 
     def on_mouse_move(self, event):
-        if event.handled or self._selection_callback is not None:
+        if event.handled or self._selection_callbacks:
             return
 
         if 1 in event.buttons or 2 in event.buttons:
@@ -679,7 +678,7 @@ class Canvas(vispy.app.Canvas):
         self.update()
 
     def grab_selection_area(self, callback):
-        self._selection_callback = callback
+        self._selection_callbacks.append(callback)
 
     def planeRotation(self, event, delta=(0,0)):
         delta = np.asarray(delta, dtype=np.float32)

--- a/plato/draw/vispy/Scene.py
+++ b/plato/draw/vispy/Scene.py
@@ -44,6 +44,13 @@ class Scene(draw.Scene):
         super(Scene, self).__init__(*args, **kwargs)
         self._canvas = Canvas(self, **canvas_kwargs)
 
+        # there is a cyclic dependency: many features depend on having
+        # a canvas initialized, but the canvas is what determines some
+        # of our attributes. Here we re-enable features that may have
+        # been skipped the first time around.
+        for (name, params) in list(self._enabled_features.items()):
+            self.enable(name, **params)
+
     @property
     def zoom(self):
         return self._zoom

--- a/test/test_Scene.py
+++ b/test/test_Scene.py
@@ -97,5 +97,49 @@ class SceneTests(unittest.TestCase):
         with self.assertRaises(IndexError):
             scene[5]
 
+    def test_transform_identity(self):
+        scene = draw.Scene(
+            translation=(-1, 2, -3), rotation=(1./np.sqrt(2), 1./np.sqrt(2), 0, 0),
+            zoom=5)
+
+        vecs = [(0, 0), (5, 7)]
+
+        for space in ['pixels_gui', 'pixels', 'ndc', 'scene']:
+            transformed = scene.transform(vecs, space, space)
+            np.testing.assert_allclose(vecs, transformed, atol=1e-4)
+
+    def test_transform_center(self):
+        scene = draw.Scene(
+            translation=(-1, 2, -3), rotation=(1./np.sqrt(2), 1./np.sqrt(2), 0, 0),
+            zoom=7)
+
+        centers = dict(
+            pixels_gui=np.array(scene.size)*scene.pixel_scale/2,
+            pixels=np.array(scene.size)*scene.pixel_scale/2,
+            ndc=(0, 0),
+            scene=-scene.translation[:2],
+        )
+
+        for (dest_name, val) in centers.items():
+            transformed = scene.transform([(0, 0)], 'ndc', dest_name)
+            np.testing.assert_allclose([val], transformed, atol=1e-4)
+
+    def test_transform_corner(self):
+        scene = draw.Scene(
+            translation=(-1, 2, -3), rotation=(1./np.sqrt(2), 1./np.sqrt(2), 0, 0),
+            zoom=9)
+
+        # top right corner for each coordinate space
+        corners = dict(
+            pixels_gui=(scene.size[0]*scene.pixel_scale, 0),
+            pixels=scene.size*scene.pixel_scale,
+            ndc=(1, 1),
+            scene=(0.5*scene.size/scene.zoom - scene.translation[:2]),
+        )
+
+        for (dest_name, val) in corners.items():
+            transformed = scene.transform([(1, 1)], 'ndc', dest_name)
+            np.testing.assert_allclose([val], transformed, atol=1e-4)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a real API to select points and areas in vispy Scenes (rather than hiding the functionality in a method of an undocumented member). It also adds a `Scene.transform` function and fixes a bug where some features wouldn't be enabled when passed in while initializing the `Scene`.