### PR TITLE
Enable specifying mpl figure when saving

### DIFF
--- a/plato/draw/matplotlib/Scene.py
+++ b/plato/draw/matplotlib/Scene.py
@@ -102,12 +102,12 @@ class Scene(draw.Scene):
         (figure, _) = self.render(figure, axes)
         return figure.show()
 
-    def save(self, filename):
+    def save(self, filename, figure=None, axes=None):
         """Render and save an image of this Scene.
 
         :param filename: target filename to save the image into
         """
-        (figure, _) = self.render()
+        (figure, _) = self.render(figure, axes)
         return figure.savefig(filename, dpi=figure.dpi, bbox_inches='tight',
                               pad_inches=0)
 


### PR DESCRIPTION
Hiya, and thanks for making this - I tried a lot of different 3D drawing packages before I settled on plato!

I'm currently using plato to generate a lot of views of a material crystal (like a molecule, but for metals and similar - basically lots of atoms). I needed something that could save the visualisation into a movie. What I'm doing is saving lots of individual frames using matplotlib, and then using ffmpeg to stitch it together. It's working nicely.

I'm using plato in jupyter notebook, and there any call to `plt.figure()` generates a figure in the notebook output. So when I generate 250 images, the notebook displays this. It actually handles it surprisingly well, but I thought it would be better to nip this in the bud before I try braving something with several thousand images.

So here I give the option to let the user reuse a certain figure.