### PR TITLE
Add Mesh to fresnel backend.

### DIFF
--- a/doc/source/fresnel.rst
+++ b/doc/source/fresnel.rst
@@ -36,6 +36,9 @@ Fresnel Backend
 .. autoclass:: Lines
    :members:
 
+.. autoclass:: Mesh
+   :members:
+
 .. autoclass:: SphereUnions
    :members:
 

--- a/plato/draw/fresnel/FresnelPrimitive.py
+++ b/plato/draw/fresnel/FresnelPrimitive.py
@@ -1,28 +1,27 @@
 import fresnel
 
-DEFAULT_MATERIAL = fresnel.material.Material(solid=0,
-                                             color=(0, 0, 0),
-                                             primitive_color_mix=1,
-                                             roughness=0.3,
-                                             specular=0.5,
-                                             spec_trans=0,
-                                             metal=0)
 
-SOLID_MATERIAL = fresnel.material.Material(solid=1,
-                                           color=(0, 0, 0),
-                                           primitive_color_mix=1,
-                                           roughness=0.3,
-                                           specular=0.5,
-                                           spec_trans=0,
-                                           metal=0)
+def _get_default_material(solid=0):
+    """Return a default material type.
+
+    2D shapes should use ``solid=1`` to remove lighting effects.
+    """
+    return fresnel.material.Material(
+        solid=solid,
+        color=(0, 0, 0),
+        primitive_color_mix=1,
+        roughness=0.3,
+        specular=0.5,
+        spec_trans=0,
+        metal=0,
+    )
 
 
 class FresnelPrimitive(object):
-    """A mixin class that defines a default :py:class:`fresnel.material.Material`.
-    """
+    """A mixin class that defines a default :py:class:`fresnel.material.Material`."""
 
     def __init__(self, *args, **kwargs):
-        self._material = kwargs.get('material', DEFAULT_MATERIAL)
+        self._material = kwargs.get("material", _get_default_material(solid=0))
         super().__init__(*args, **kwargs)
 
 
@@ -34,5 +33,5 @@ class FresnelPrimitiveSolid(FresnelPrimitive):
     """
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('material', SOLID_MATERIAL)
+        kwargs.setdefault("material", _get_default_material(solid=1))
         super().__init__(*args, **kwargs)

--- a/plato/draw/fresnel/Mesh.py
+++ b/plato/draw/fresnel/Mesh.py
@@ -1,0 +1,34 @@
+import itertools
+
+import fresnel
+import numpy as np
+
+from ... import draw
+from ..internal import ShapeAttribute, ShapeDecorator
+from .FresnelPrimitive import FresnelPrimitive
+
+@ShapeDecorator
+class Mesh(FresnelPrimitive, draw.Mesh):
+    __doc__ = draw.Mesh.__doc__
+
+    _ATTRIBUTES = draw.Mesh._ATTRIBUTES + list(
+        itertools.starmap(ShapeAttribute, [
+        ('outline', np.float32, 0, 0, False,
+         'Outline width for all particles')
+    ]))
+
+    def render(self, scene):
+        # Convert from vertices shape (num_unique_vertices, 3) and indices with
+        # shape (num_triangles, 3) to (3 * num_triangles, 3) array
+        vertices = self.vertices[self.indices].reshape(-1, 3)
+        color = fresnel.color.linear(self.colors)[self.indices].reshape(-1, 3)
+        self._material.primitive_color_mix = self.shape_color_fraction
+        geometry = fresnel.geometry.Mesh(
+            scene=scene,
+            vertices=vertices,
+            position=self.positions,
+            orientation=self.orientations,
+            color=color,
+            material=self._material,
+            outline_width=self.outline)
+        return geometry

--- a/plato/draw/fresnel/__init__.py
+++ b/plato/draw/fresnel/__init__.py
@@ -21,6 +21,7 @@ from .ConvexPolyhedra import ConvexPolyhedra
 from .Disks import Disks
 from .Ellipsoids import Ellipsoids
 from .Lines import Lines
+from .Mesh import Mesh
 from .Polygons import Polygons
 from .Spheres import Spheres
 from .SphereUnions import SphereUnions


### PR DESCRIPTION
## Summary
This PR adds `Mesh` support to the `fresnel` backend. It converts the input arrays of vertices and indices into a `(3T, 3)` array of triangle vertices, where `T` is the number of triangles.

I also refactored fresnel's default material support so that every primitive gets a newly-constructed Material instance, rather than sharing a module-level constant. **I removed the module constants `plato.draw.fresnel.FresnelPrimitive.DEFAULT_MATERIAL` and `plato.draw.fresnel.FresnelPrimitive.SOLID_MATERIAL` which is technically an API break, but I don't think any external code would have relied on these default materials.**

References:
- https://fresnel.readthedocs.io/en/stable/examples/01-Primitives/03-Mesh-geometry.html
- https://fresnel.readthedocs.io/en/stable/module-geometry.html#fresnel.geometry.Mesh

## Caveats
It does not fully support the `shape_colors` attribute. The cases that are handled correctly are:
- All shapes have the same shape color
- The `shape_color_fraction` is 0

In the case where multiple distinct shape colors are provided and `shape_color_fraction > 0`, only the first shape color is used.
