### PR TITLE
Support fresnel 0.13.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## v1.12 - *unreleased*
 
+- Update fresnel backend to support fresnel 0.13.0, drops support for fresnel < 0.12.0 (bdice@umich)
 - Allow matplotlib scenes to specify figure or axis when saving (thomasaarholt@uio)
 
 ## v1.11 - 2020/06/25

--- a/plato/draw/fresnel/Scene.py
+++ b/plato/draw/fresnel/Scene.py
@@ -8,7 +8,7 @@ class Scene(draw.Scene):
     __doc__ = (draw.Scene.__doc__ or '') + """
     This Scene supports the following features:
 
-    * *antialiasing*: Enable antialiasing, for the preview tracer only. This uses fresnel's aa_level=3 if set, 0 otherwise.
+    * *antialiasing*: Enable antialiasing, for the preview tracer only.
     * *pathtracer*: Enable the path tracer. Accepts parameter ``samples`` with default value 64.
     * *directional_light*: Add directional lights. The given vector(s) indicates the light direction. The length of the vector(s) determines the magnitude of the light(s).
     * *ambient_light*: Enable ambient lighting. The given value indicates the magnitude of the light.
@@ -67,7 +67,12 @@ class Scene(draw.Scene):
         camera_position = rowan.rotate(rowan.conjugate(self.rotation), -self.translation)
         camera_look_at = camera_position + rowan.rotate(rowan.conjugate(self.rotation), [0, 0, -1])
         camera_height = self.size[1]/self.zoom
-        self._fresnel_scene.camera = fresnel.camera.orthographic(
+        try:
+            orthographic_camera = fresnel.camera.Orthographic
+        except AttributeError:
+            # Support fresnel < 0.13.0
+            orthographic_camera = fresnel.camera.orthographic
+        self._fresnel_scene.camera = orthographic_camera(
             position=camera_position,
             look_at=camera_look_at,
             up=camera_up,
@@ -106,7 +111,7 @@ class Scene(draw.Scene):
         else:
             # Use preview tracer by default
             tracer = self._preview_tracer
-            tracer.aa_level = 3 if 'antialiasing' in self.enabled_features else 0
+            tracer.anti_alias = 'antialiasing' in self.enabled_features
             render_function = tracer.render
 
         self._output = render_function(self._fresnel_scene)

--- a/test/test_pythreejs.py
+++ b/test/test_pythreejs.py
@@ -11,7 +11,7 @@ class PythreejsTests(unittest.TestCase):
         fname = get_fname('pythreejs_test_scenes.html')
 
         NbConvertApp.launch_instance(
-            argv=['--execute', '--output', fname, src])
+            argv=['--execute', '--to', 'html', '--output', fname, src])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updates fresnel backend to support the latest fresnel syntax for `anti_alias` in the preview tracer and `Orthographic` camera.

Until this is released, the CI tests for freud-examples (which includes a visualization notebook) will fail.